### PR TITLE
Update help links to docusarus site

### DIFF
--- a/src/sections/curate/curate.html
+++ b/src/sections/curate/curate.html
@@ -127,7 +127,7 @@
             <h2>Organize dataset</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/organize-dataset"
+              href="https://docs.sodaforsparc.io/docs/prepare-dataset/organize-dataset"
               >Need help?</a
             >
           </div>

--- a/src/sections/manage_datasets/manage_datasets.html
+++ b/src/sections/manage_datasets/manage_datasets.html
@@ -25,7 +25,7 @@
             <h2>Manage Datasets - Create a new dataset</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Create-a-new-dataset"
+              href="https://docs.sodaforsparc.io/docs/manage-dataset/create-a-new-dataset"
               >Need help?</a
             >
           </div>
@@ -323,7 +323,7 @@
               <h2>Manage Datasets - Rename an existing dataset</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Rename-an-existing-dataset"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/rename-an-existing-dataset"
                 >Need help?</a
               >
             </div>
@@ -638,7 +638,7 @@
               <h2>Manage Datasets - Make PI owner of dataset</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Make-PI-owner-of-dataset"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/make-pi-owner-of-dataset"
                 >Need help?</a
               >
             </div>
@@ -1014,7 +1014,7 @@
               <h2>Manage Datasets - Add/edit dataset permissions</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Add-edit-permissions"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/add-edit-permissions"
                 >Need help?</a
               >
             </div>
@@ -1355,7 +1355,7 @@
                 >Please select the user for whom you want to modify permissions:
                 <i
                   class="fas fa-info-circle popover-tooltip"
-                  data-content="See our associated <a href='https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Add-edit-permissions' target='_blank'> documentation</a> to learn more about the meaning of the different roles and what type of permissions they provide."
+                  data-content="See our associated <a href='https://docs.sodaforsparc.io/docs/manage-dataset/Add-edit-permissions' target='_blank'> documentation</a> to learn more about the meaning of the different roles and what type of permissions they provide."
                   rel="popover"
                   data-html="true"
                   data-placement="right"
@@ -1462,7 +1462,7 @@
                 >Please select the team for whom you want to modify permissions:
                 <i
                   class="fas fa-info-circle popover-tooltip"
-                  data-content="See our associated <a href='https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Add-edit-permissions' target='_blank'> documentation</a> to learn more about the meaning of the different roles and what type of permissions they provide."
+                  data-content="See our associated <a href='https://docs.sodaforsparc.io/docs/manage-dataset/Add-edit-permissions' target='_blank'> documentation</a> to learn more about the meaning of the different roles and what type of permissions they provide."
                   rel="popover"
                   data-html="true"
                   data-placement="right"
@@ -1612,7 +1612,7 @@
               <h2>Manage Datasets - Add/edit subtitle</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Add-edit-subtitle"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/add-edit-subtitle"
                 >Need help?</a
               >
             </div>
@@ -1945,7 +1945,7 @@
               <h2>Manage Datasets - Add/edit tags</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Add-edit-tags"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/add-edit-tags"
                 >Need help?</a
               >
             </div>
@@ -2260,7 +2260,7 @@
               <h2>Manage Datasets - Add/edit description</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Add-edit-description"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/add-edit-description"
                 >Need help?</a
               >
             </div>
@@ -2555,7 +2555,7 @@
                                   placing it into the appropriate section(s).
                                   <br />
                                   <a
-                                    href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Add-edit-description"
+                                    href="https://docs.sodaforsparc.io/docs/manage-dataset/Add-edit-description"
                                     >Learn more.</a
                                   >
                                 </strong>
@@ -2791,7 +2791,7 @@
               <h2>Manage Datasets - Upload a banner image</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Upload-a-banner-image"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/upload-a-banner-image"
                 >Need help?</a
               >
             </div>
@@ -3249,7 +3249,7 @@
               <h2>Manage Datasets - Assign a license</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Assign-a-license"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/assign-a-license"
                 >Need help?</a
               >
             </div>
@@ -3597,7 +3597,7 @@
               <h2>Manage Datasets - Upload a local dataset</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/Upload-a-local-dataset-to-Pennsieve"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/upload-a-local-dataset-to-pennsieve"
                 >Need help?</a
               >
             </div>
@@ -3985,7 +3985,7 @@
               <h2>Manage Datasets - View/change dataset status</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/manage-dataset/View-and-change-status"
+                href="https://docs.sodaforsparc.io/docs/manage-dataset/view-and-change-status"
                 >Need help?</a
               >
             </div>

--- a/src/sections/post_curation/post_curation.html
+++ b/src/sections/post_curation/post_curation.html
@@ -24,7 +24,7 @@
             <h2>Disseminate Datasets - Share with Curation Team</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/disseminate-dataset/Share-with-curation-team"
+              href="https://docs.sodaforsparc.io/docs/disseminate-dataset/share-with-curation-team"
               >Need help?</a
             >
           </div>
@@ -338,7 +338,7 @@
             <h2>Disseminate Datasets - Share with SPARC Consortium</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/disseminate-dataset/Share-with-SPARC-Consortium"
+              href="https://docs.sodaforsparc.io/docs/disseminate-dataset/share-with-sparc-consortium"
               >Need help?</a
             >
           </div>
@@ -653,7 +653,7 @@
             <h2>Disseminate Datasets - Submit for pre-publishing review</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/disseminate-dataset/Submit-for-pre-publishing-review"
+              href="https://docs.sodaforsparc.io/docs/disseminate-dataset/submit-for-pre-publishing-review"
               >Need help?</a
             >
           </div>

--- a/src/sections/prepare_metadata/prepare_metadata.html
+++ b/src/sections/prepare_metadata/prepare_metadata.html
@@ -9991,7 +9991,7 @@
             <h2>Prepare Metadata - Create manifest.xlsx</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/create-submission"
+              href="https://docs.sodaforsparc.io/docs/prepare-metadata/create-manifest-files"
               >Need help?</a
             >
           </div>

--- a/src/sections/prepare_metadata/prepare_metadata.html
+++ b/src/sections/prepare_metadata/prepare_metadata.html
@@ -32,7 +32,7 @@
               <h2>Prepare Metadata - Download templates</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/prepare-metadata/Download-templates"
+                href="https://docs.sodaforsparc.io/docs/prepare-metadata/download-templates"
                 >Need help?</a
               >
             </div>
@@ -967,7 +967,7 @@
             <h2>Prepare Metadata - Create submission.xlsx</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/prepare-metadata/Create-submission-xlsx"
+              href="https://docs.sodaforsparc.io/docs/prepare-metadata/create-submission"
               >Need help?</a
             >
           </div>
@@ -2097,7 +2097,7 @@
             <h2>Prepare Metadata - Create dataset_description.xlsx</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/prepare-metadata/Create-dataset_description-xlsx"
+              href="https://docs.sodaforsparc.io/docs/prepare-metadata/create-dataset-description"
               >Need help?</a
             >
           </div>
@@ -4086,7 +4086,7 @@
               <h2>Prepare Metadata - Create subjects.xlsx</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/prepare-metadata/Create-subjects-xlsx"
+                href="https://docs.sodaforsparc.io/docs/prepare-metadata/create-subjects"
                 >Need help?</a
               >
             </div>
@@ -6228,7 +6228,7 @@
               <h2>Prepare Metadata - Create samples.xlsx</h2>
               <a
                 target="_blank"
-                href="https://fairdataihub.org/sodaforsparc/docs/prepare-metadata/Create-samples-xlsx"
+                href="https://docs.sodaforsparc.io/docs/prepare-metadata/create-samples"
                 >Need help?</a
               >
             </div>
@@ -8064,7 +8064,7 @@
             <h2>Prepare Metadata - Create CHANGES.txt</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/prepare-metadata/Create-changes-txt"
+              href="https://docs.sodaforsparc.io/docs/prepare-metadata/create-changes-txt"
               >Need help?</a
             >
           </div>
@@ -9028,7 +9028,7 @@
             <h2>Prepare Metadata - Create README.txt</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/prepare-metadata/Create-readme-txt"
+              href="https://docs.sodaforsparc.io/docs/prepare-metadata/create-readme"
               >Need help?</a
             >
           </div>
@@ -9991,7 +9991,7 @@
             <h2>Prepare Metadata - Create manifest.xlsx</h2>
             <a
               target="_blank"
-              href="https://fairdataihub.org/sodaforsparc/docs/Create-submission-xlsx"
+              href="https://fairdataihub.org/sodaforsparc/docs/create-submission"
               >Need help?</a
             >
           </div>


### PR DESCRIPTION
Need Help? links in app now point to the Docusarus docs subdomain for soda for sparc rather than fairdataihub/docs.