### PR TITLE
feat: Dataset title rules updated to exclude \.,

### DIFF
--- a/src/pyflask/manageDatasets/manage_datasets.py
+++ b/src/pyflask/manageDatasets/manage_datasets.py
@@ -74,7 +74,7 @@ upload_directly_to_bf = 0
 initial_bfdataset_size_submit = 0
 
 forbidden_characters = '<>:"/\|?*'
-forbidden_characters_bf = '\/:*?"<>'
+forbidden_characters_bf = '\/:*?"<>.,'
 
 SODA_SPARC_API_KEY = "SODA-Pennsieve"
 

--- a/src/pyflask/pysodaUtils/pysodaUtils.py
+++ b/src/pyflask/pysodaUtils/pysodaUtils.py
@@ -111,7 +111,7 @@ def check_forbidden_characters(my_string):
     return regex.search(my_string) is not None or "\\" in r"%r" % my_string
 
 
-forbidden_characters_bf = '\/:*?"<>'
+forbidden_characters_bf = '\/:*?"<>.,'
 
 def check_forbidden_characters_ps(my_string):
     """

--- a/src/pyflask/pysodaUtils/pysodaUtils.py
+++ b/src/pyflask/pysodaUtils/pysodaUtils.py
@@ -111,7 +111,7 @@ def check_forbidden_characters(my_string):
     return regex.search(my_string) is not None or "\\" in r"%r" % my_string
 
 
-forbidden_characters_bf = '\/:*?"<>.,'
+forbidden_characters_bf = '\/\\:*?"<>\.,'
 
 def check_forbidden_characters_ps(my_string):
     """

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -1074,7 +1074,7 @@ const savePageChanges = async (pageBeingLeftID) => {
         errorArray.push({
           type: "notyf",
           message:
-            "A Pennsieve dataset name cannot contain any of the following characters: /:*?'<>.",
+            "A Pennsieve dataset name cannot contain any of the following characters: \\/:*?'<>.,",
         });
       }
       if (!datasetSubtitleInput) {

--- a/src/renderer/src/scripts/manage-dataset/manage-dataset.js
+++ b/src/renderer/src/scripts/manage-dataset/manage-dataset.js
@@ -42,7 +42,7 @@ document.querySelectorAll(".ds-dd.organization").forEach((dropdownElement) => {
   });
 });
 
-var forbidden_characters_bf = '/:*?"<>';
+var forbidden_characters_bf = '\/\\:*?"<>\.,';
 
 window.check_forbidden_characters_ps = (my_string) => {
   // Args:
@@ -121,7 +121,7 @@ $("#bf-new-dataset-name").on("keyup", () => {
   if (newName !== "") {
     if (window.check_forbidden_characters_ps(newName)) {
       Swal.fire({
-        title: "A Pennsieve dataset name cannot contain any of the following characters: /:*?'<>.",
+        title: "A Pennsieve dataset name cannot contain any of the following characters: \\/:*?'<>.,",
         icon: "error",
         backdrop: "rgba(0,0,0, 0.4)",
         heightAuto: false,
@@ -142,7 +142,7 @@ $("#bf-rename-dataset-name").on("keyup", () => {
   if (newName !== "") {
     if (window.check_forbidden_characters_ps(newName)) {
       Swal.fire({
-        title: "A Pennsieve dataset name cannot contain any of the following characters: /:*?'<>.",
+        title: "A Pennsieve dataset name cannot contain any of the following characters: \\/:*?'<>.,",
         backdrop: "rgba(0,0,0, 0.4)",
         heightAuto: false,
         icon: "error",

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -6558,7 +6558,7 @@ $("#inputNewNameDataset").keyup(function () {
       document.getElementById("div-confirm-inputNewNameDataset").style.display = "none";
       $("#btn-confirm-new-dataset-name").hide();
       document.getElementById("para-new-name-dataset-message").innerHTML =
-        "Error: A Pennsieve dataset name cannot contain any of the following characters: /:*?'<>.";
+        "Error: A Pennsieve dataset name cannot contain any of the following characters: \\/:*?'<>.,";
       // $("#nextBtn").prop("disabled", true)
       $("#Question-generate-dataset-generate-div-old").removeClass("show");
       $("#div-confirm-inputNewNameDataset").css("display", "none");


### PR DESCRIPTION
Pennsieve has updated their dataset title rules to exclude \., so SODA now handles excluding these characters from dataset names.