### PR TITLE
fix: SODA-Pennsieve key in config.ini becomes default if it exists and is broken

### DIFF
--- a/src/pyflask/configUtils/config.py
+++ b/src/pyflask/configUtils/config.py
@@ -54,8 +54,8 @@ def lowercase_account_names(config, account_name, configpath):
 
     # add the section back with the lowercase account name
     config.add_section(formatted_account_name) 
-    config.set(formatted_account_name, "api_token", config.get(formatted_account_name, "api_token"))
-    config.set(formatted_account_name, "api_secret", config.get(formatted_account_name, "api_secret"))
+    config.set(formatted_account_name, "api_token", config.get(account_name, "api_token"))
+    config.set(formatted_account_name, "api_secret", config.get(account_name, "api_secret"))
 
     # set the global default_profile option to lowercase
     config.set("global", "default_profile", formatted_account_name)

--- a/src/pyflask/manageDatasets/manage_datasets.py
+++ b/src/pyflask/manageDatasets/manage_datasets.py
@@ -265,12 +265,7 @@ def bf_get_accounts():
     sections = config.sections()
     global namespace_logger
 
-    if SODA_SPARC_API_KEY in sections:
-        lowercase_account_names(config, SODA_SPARC_API_KEY, configpath)
-        with contextlib.suppress(Exception):
-            get_access_token()
-            return SODA_SPARC_API_KEY.lower()
-    elif "global" in sections:
+    if "global" in sections:
         if "default_profile" in config["global"]:
             default_profile = config["global"]["default_profile"]
             if default_profile in sections:
@@ -282,6 +277,13 @@ def bf_get_accounts():
                 except Exception as e:
                     namespace_logger.info("Failed to authenticate the stored token")
                     abort(401, e)
+    
+    elif SODA_SPARC_API_KEY in sections:
+        lowercase_account_names(config, SODA_SPARC_API_KEY, configpath)
+        with contextlib.suppress(Exception):
+            get_access_token()
+            return SODA_SPARC_API_KEY.lower()
+    
     else:
         namespace_logger.info("No default account found")
         for account in sections:


### PR DESCRIPTION
## Summary by Sourcery

Fix the handling of the SODA-Pennsieve key in the configuration to ensure it becomes the default if it exists and is broken, by adjusting the order of checks in the account retrieval logic.

Bug Fixes:
- Fix the logic to correctly set the SODA-Pennsieve key as the default in the configuration if it exists and is broken.