### PR TITLE
fix: pennsieve agent check in advanced features cannot differentiate uninstalled from not running agent states

### DIFF
--- a/src/renderer/src/assets/component-utils/addDatasetAndOrganizationCards.js
+++ b/src/renderer/src/assets/component-utils/addDatasetAndOrganizationCards.js
@@ -165,7 +165,7 @@ const addDatasetAndOrganizationCardComponents = () => {
     currentParentTab: "add_edit_banner_parent-tab",
     action: "delete",
     section: "individual-question manage-dataset",
-    dataNext: "div_add_edit_banner",
+    dataNext: "div_add_edit_banner_image_agent_check",
     fields: [
       FIELD_OPTIONS.ACCOUNT_EDITABLE,
 

--- a/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
+++ b/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
@@ -22,15 +22,21 @@ const deletePennsieveAgentDBFilesAndRestart = async () => {
     "/.pennsieve/pennsieve_agent.db-wal",
   ];
 
-  // Stop the Pennsieve agent to free up the database files
-  await window.spawn.stopPennsieveAgent();
+  try {
+    // Stop the Pennsieve agent to free up the database files
+    await window.spawn.stopPennsieveAgent();
 
-  // Delete the Pennsieve agent database files
-  for (const file of filesToDelete) {
-    const filePath = `${window.homeDirectory}${file}`;
-    if (window.fs.existsSync(filePath)) {
-      await window.fs.unlink(filePath);
+    // Delete the Pennsieve agent database files
+    for (const file of filesToDelete) {
+      const filePath = `${window.homeDirectory}${file}`;
+      if (window.fs.existsSync(filePath)) {
+        await window.fs.unlink(filePath);
+      } else {
+        console.error(`Unable to find Pennsieve agent DB file: ${filePath}`);
+      }
     }
+  } catch (error) {
+    console.error("Error deleting Pennsieve agent DB files:", error);
   }
 
   // Restart the Pennsieve agent check

--- a/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
+++ b/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
@@ -108,6 +108,7 @@ const PennsieveAgentCheckDisplay = () => {
     postPennsieveAgentCheckAction,
   } = useGlobalStore();
 
+  // If the Pennsieve agent check is in progress, display a loading spinner
   if (pennsieveAgentCheckInProgress === true) {
     return (
       <FullWidthContainer>
@@ -121,6 +122,7 @@ const PennsieveAgentCheckDisplay = () => {
     );
   }
 
+  // If an error message title and message are present, display the error message
   if (pennsieveAgentCheckError?.title && pennsieveAgentCheckError?.message) {
     return (
       <FullWidthContainer>
@@ -142,6 +144,7 @@ const PennsieveAgentCheckDisplay = () => {
     );
   }
 
+  // If the Pennsieve agent is not installed, display a message with a download link
   if (pennsieveAgentInstalled === false) {
     return (
       <FullWidthContainer>
@@ -176,7 +179,8 @@ const PennsieveAgentCheckDisplay = () => {
     );
   }
 
-  if (pennsieveAgentOutputErrorMessage === true) {
+  // If the Pennsieve agent check returned an error message, display the error message
+  if (pennsieveAgentOutputErrorMessage != null) {
     return (
       <FullWidthContainer>
         <PennsieveAgentErrorMessageDisplay errorMessage={pennsieveAgentOutputErrorMessage} />
@@ -184,6 +188,7 @@ const PennsieveAgentCheckDisplay = () => {
     );
   }
 
+  // If the Pennsieve agent is not up to date, display a message with a download link to the latest version
   if (pennsieveAgentUpToDate === false) {
     return (
       <FullWidthContainer>
@@ -223,6 +228,7 @@ const PennsieveAgentCheckDisplay = () => {
     );
   }
 
+  // If the Pennsieve agent check was successful (no flags occurred), display a success message
   return (
     <FullWidthContainer>
       <Stack mt="sm" align="center" mx="sm">

--- a/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
+++ b/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
@@ -11,7 +11,6 @@ const CLOSE_SODA_BUTTON_TEXT = "Close SODA";
 const KNOWN_ERROR_MESSAGES = [
   "UNIQUE constraint failed:",
   "NotAuthorizedException: Incorrect username or password.",
-  "401 Error Creating new UserSettings",
   "UserSettings" /* If the error message contains "UserSettings", it is likely solved by deleting the Pennsieve Agent database files */,
 ];
 

--- a/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
+++ b/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
@@ -72,8 +72,14 @@ const PennsieveAgentErrorMessageDisplay = ({ errorMessage }) => {
               <>
                 <Text>
                   This is a known issue with the Pennsieve Agent. It can typically be resolved by
-                  deleting the local Pennsieve Agent database files. Would you like SODA to do this
-                  and restart the Agent?
+                  deleting the local Pennsieve Agent database files. You can refer to the
+                  <ExternalLink
+                    href="https://docs.sodaforsparc.io/docs/common-errors/trouble-starting-the-pennsieve-agent-in-soda"
+                    buttonText="SODA documentation"
+                    buttonType="anchor"
+                  />
+                  for information on how to fix the issue manually. SODA can also attempt to fix the
+                  issue for you. Would you like to have SODA try to fix the issue?
                 </Text>
                 <Group justify="center" mt="sm">
                   <Button onClick={deletePennsieveAgentDBFilesAndRestart}>

--- a/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
+++ b/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
@@ -12,6 +12,7 @@ const KNOWN_ERROR_MESSAGES = [
   "UNIQUE constraint failed:",
   "NotAuthorizedException: Incorrect username or password.",
   "401 Error Creating new UserSettings",
+  "UserSettings" /* If the error message contains "UserSettings", it is likely solved by deleting the Pennsieve Agent database files */,
 ];
 
 // Utility Functions
@@ -22,6 +23,10 @@ const deletePennsieveAgentDBFilesAndRestart = async () => {
     "/.pennsieve/pennsieve_agent.db-wal",
   ];
 
+  // Stop the Pennsieve agent to free up the database files
+  await window.spawn.stopPennsieveAgent();
+
+  // Delete the Pennsieve agent database files
   for (const file of filesToDelete) {
     const filePath = `${window.homeDirectory}${file}`;
     if (window.fs.existsSync(filePath)) {
@@ -29,6 +34,7 @@ const deletePennsieveAgentDBFilesAndRestart = async () => {
     }
   }
 
+  // Restart the Pennsieve agent check
   await window.checkPennsieveAgent();
 };
 

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -5,6 +5,7 @@ import { hideAllSectionsAndDeselectButtons } from "../../assets/nav";
 import { existingDataset, modifyDataset } from "../../assets/lotties/lotties";
 import lottie from "lottie-web";
 import Swal from "sweetalert2";
+import { clientError } from "../others/http-error-handler/error-handler";
 
 while (!window.baseHtmlLoaded) {
   await new Promise((resolve) => setTimeout(resolve, 100));
@@ -336,17 +337,23 @@ document.querySelector("#btn-confirm-dataset-manifest-page").addEventListener("c
     console.error("Error with agent" + e);
   }
 
+  console.log(agentCheckSuccessful)
+
   if (!agentCheckSuccessful) {
     return;
   }
 
-  // show the btn-pul-ds-manifest button
-  document.querySelector("#btn-pull-ds-manifest").classList.remove("hidden");
+  // show the btn-pull-ds-manifest button
+  document.querySelector("#div-btn-pull-ds-manifest").classList.remove("hidden");
 
   // scroll to the button
-  document.querySelector("#btn-pull-ds-manifest").scrollIntoView({ behavior: "smooth" });
+  document.querySelector("#div-btn-pull-ds-manifest").scrollIntoView({ behavior: "smooth" });
 });
 
 document.querySelector("#btn-pull-ds-manifest").addEventListener("click", async function () {
+  try {
   window.generateManifestFolderLocallyForEdit(this);
+  } catch (e) {
+    clientError(e)
+  }
 });

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -337,7 +337,7 @@ document.querySelector("#btn-confirm-dataset-manifest-page").addEventListener("c
     console.error("Error with agent" + e);
   }
 
-  console.log(agentCheckSuccessful)
+  console.log(agentCheckSuccessful);
 
   if (!agentCheckSuccessful) {
     return;
@@ -352,8 +352,8 @@ document.querySelector("#btn-confirm-dataset-manifest-page").addEventListener("c
 
 document.querySelector("#btn-pull-ds-manifest").addEventListener("click", async function () {
   try {
-  window.generateManifestFolderLocallyForEdit(this);
+    window.generateManifestFolderLocallyForEdit(this);
   } catch (e) {
-    clientError(e)
+    clientError(e);
   }
 });

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -232,14 +232,15 @@ $("#advanced-start-over-button").on("click", async () => {
     document.getElementById("input-manifest-local-folder-dataset").placeholder = "Browse here";
 
     // hide the pennsieve agent check section
-    document.getElementById("advanced-features-manifest-generation-pennsieve-agent-check").classList.add("hidden");
+    document
+      .getElementById("advanced-features-manifest-generation-pennsieve-agent-check")
+      .classList.add("hidden");
     // hide the pull manifest information button's div
     document.getElementById("div-btn-pull-ds-manifest").classList.add("hidden");
     // set the dataset text to none
     document.querySelector("#bf_dataset_create_manifest").textContent = "None";
-    // hide the confirm button 
-    document.querySelector("#btn-confirm-dataset-manifest-page").classList.add("hidden")
-
+    // hide the confirm button
+    document.querySelector("#btn-confirm-dataset-manifest-page").classList.add("hidden");
 
     // Hide the all sub-questions for generating manifest
     document.getElementById("Question-prepare-manifest-2").classList.remove("show");

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -370,54 +370,43 @@ document.querySelector("#btn-pull-ds-manifest").addEventListener("click", async 
   }
 });
 
+function createAgentCHeckObserver(targetDiv, successCallback) {
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      const textToCheck = "The Pennsieve Agent is running and ready to upload!";
+      if (targetDiv.textContent.includes(textToCheck)) {
+        successCallback();
+      }
+    });
+  });
+
+  observer.observe(targetDiv, { childList: true, subtree: true, characterData: true });
+  return observer;
+}
+
 // create a mutation observer on this id advanced-features-manifest-generation-pennsieve-agent-check
 // to check if the agent check has been completed and we can show the div-btn-pull-ds-manifest
 const agentCheckDiv = document.querySelector(
   "#advanced-features-manifest-generation-pennsieve-agent-check"
 );
-const agentCheckObserver = new MutationObserver((mutations) => {
-  mutations.forEach(
-    (mutation) => {
-      const textToCheck = "The Pennsieve Agent is running and ready to upload!";
-      const isTextPresent = agentCheckDiv.textContent.includes(textToCheck);
-      if (isTextPresent) {
-        document.querySelector("#div-btn-pull-ds-manifest").classList.remove("hidden");
-      }
-    },
-    { attributes: true }
-  );
+createAgentCHeckObserver(agentCheckDiv, () => {
+  document.querySelector("#div-btn-pull-ds-manifest").classList.remove("hidden");
 });
-
-agentCheckObserver.observe(agentCheckDiv, { childList: true, subtree: true, characterData: true });
 
 // add the same mutatiomn observer for the banner image pennsieve agent check
 const agentCheckBannerImageDiv = document.querySelector(
   "#advanced-features-banner-image-pennsieve-agent-check"
 );
-const agentCheckBannerImageDivObserver = new MutationObserver((mutations) => {
-  mutations.forEach(
-    async (mutation) => {
-      const textToCheck = "The Pennsieve Agent is running and ready to upload!";
-      const isTextPresent = agentCheckBannerImageDiv.textContent.includes(textToCheck);
-      if (isTextPresent) {
-        await window.transitionFreeFormMode(
-          document.querySelector("#div_add_edit_banner_image_agent_check"),
-          "div_add_edit_banner_image_agent_check",
-          "delete",
-          "freeform"
-        );
-        await window.wait(1000);
 
-        // scroll the next section into view
-        document.querySelector("#edit_banner_image_button").scrollIntoView({ behavior: "smooth" });
-      }
-    },
-    { attributes: true }
+createAgentCHeckObserver(agentCheckBannerImageDiv, async () => {
+  await window.transitionFreeFormMode(
+    document.querySelector("#div_add_edit_banner_image_agent_check"),
+    "div_add_edit_banner_image_agent_check",
+    "delete",
+    "freeform"
   );
-});
+  await window.wait(1000);
 
-agentCheckBannerImageDivObserver.observe(agentCheckBannerImageDiv, {
-  childList: true,
-  subtree: true,
-  characterData: true,
+  // scroll the next section into view
+  document.querySelector("#edit_banner_image_button").scrollIntoView({ behavior: "smooth" });
 });

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -358,22 +358,22 @@ document.querySelector("#btn-pull-ds-manifest").addEventListener("click", async 
   }
 });
 
-
 // create a mutation observer on this id advanced-features-manifest-generation-pennsieve-agent-check
 // to check if the agent check has been completed and we can show the div-btn-pull-ds-manifest
-const agentCheckDiv = document.querySelector("#advanced-features-manifest-generation-pennsieve-agent-check");
+const agentCheckDiv = document.querySelector(
+  "#advanced-features-manifest-generation-pennsieve-agent-check"
+);
 const agentCheckObserver = new MutationObserver((mutations) => {
-  mutations.forEach((mutation) => {
-    const textToCheck = "The Pennsieve Agent is running and ready to upload!";
-    const isTextPresent = agentCheckDiv.textContent.includes(textToCheck);
-    if (isTextPresent) {
-      document.querySelector
-        ("#div-btn-pull-ds-manifest").classList.remove("hidden");
-    }
-
-  }, { attributes: true });
+  mutations.forEach(
+    (mutation) => {
+      const textToCheck = "The Pennsieve Agent is running and ready to upload!";
+      const isTextPresent = agentCheckDiv.textContent.includes(textToCheck);
+      if (isTextPresent) {
+        document.querySelector("#div-btn-pull-ds-manifest").classList.remove("hidden");
+      }
+    },
+    { attributes: true }
+  );
 });
 
-agentCheckObserver.observe(agentCheckDiv, { childList: true,subtree: true, characterData: true  });
-
-
+agentCheckObserver.observe(agentCheckDiv, { childList: true, subtree: true, characterData: true });

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -344,7 +344,7 @@ document.querySelector("#btn-confirm-dataset-manifest-page").addEventListener("c
   }
 
   // show the btn-pull-ds-manifest button
-  document.querySelector("#div-btn-pull-ds-manifest").classList.remove("hidden");
+  // document.querySelector("#div-btn-pull-ds-manifest").classList.remove("hidden");
 
   // scroll to the button
   document.querySelector("#div-btn-pull-ds-manifest").scrollIntoView({ behavior: "smooth" });
@@ -357,3 +357,23 @@ document.querySelector("#btn-pull-ds-manifest").addEventListener("click", async 
     clientError(e);
   }
 });
+
+
+// create a mutation observer on this id advanced-features-manifest-generation-pennsieve-agent-check
+// to check if the agent check has been completed and we can show the div-btn-pull-ds-manifest
+const agentCheckDiv = document.querySelector("#advanced-features-manifest-generation-pennsieve-agent-check");
+const agentCheckObserver = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    const textToCheck = "The Pennsieve Agent is running and ready to upload!";
+    const isTextPresent = agentCheckDiv.textContent.includes(textToCheck);
+    if (isTextPresent) {
+      document.querySelector
+        ("#div-btn-pull-ds-manifest").classList.remove("hidden");
+    }
+
+  }, { attributes: true });
+});
+
+agentCheckObserver.observe(agentCheckDiv, { childList: true,subtree: true, characterData: true  });
+
+

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -316,3 +316,37 @@ $("#button-import-banner-image").click(async () => {
   $("#edit_banner_image_modal").modal("show");
   $("#edit_banner_image_modal").addClass("show");
 });
+
+// Pennsieve Agent check display
+document.querySelector("#btn-confirm-dataset-manifest-page").addEventListener("click", async () => {
+  // hide the confirm button
+  document.querySelector("#btn-confirm-dataset-manifest-page").classList.add("hidden");
+
+  // show the Pennsieve Agent slot
+  const pennsieveAgentCheckDivId = "advanced-features-manifest-generation-pennsieve-agent-check";
+  let pennsieveAgentCheckDiv = document.querySelector(`#${pennsieveAgentCheckDivId}`);
+
+  // start agent check
+  let agentCheckSuccessful = false;
+  try {
+    pennsieveAgentCheckDiv.classList.remove("hidden");
+    // Check to make sure the Pennsieve agent is installed
+    agentCheckSuccessful = await window.checkPennsieveAgent(pennsieveAgentCheckDivId);
+  } catch (e) {
+    console.error("Error with agent" + e);
+  }
+
+  if (!agentCheckSuccessful) {
+    return;
+  }
+
+  // show the btn-pul-ds-manifest button
+  document.querySelector("#btn-pull-ds-manifest").classList.remove("hidden");
+
+  // scroll to the button
+  document.querySelector("#btn-pull-ds-manifest").scrollIntoView({ behavior: "smooth" });
+});
+
+document.querySelector("#btn-pull-ds-manifest").addEventListener("click", async function () {
+  window.generateManifestFolderLocallyForEdit(this);
+});

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -389,3 +389,35 @@ const agentCheckObserver = new MutationObserver((mutations) => {
 });
 
 agentCheckObserver.observe(agentCheckDiv, { childList: true, subtree: true, characterData: true });
+
+// add the same mutatiomn observer for the banner image pennsieve agent check
+const agentCheckBannerImageDiv = document.querySelector(
+  "#advanced-features-banner-image-pennsieve-agent-check"
+);
+const agentCheckBannerImageDivObserver = new MutationObserver((mutations) => {
+  mutations.forEach(
+    async (mutation) => {
+      const textToCheck = "The Pennsieve Agent is running and ready to upload!";
+      const isTextPresent = agentCheckBannerImageDiv.textContent.includes(textToCheck);
+      if (isTextPresent) {
+        await window.transitionFreeFormMode(
+          document.querySelector("#div_add_edit_banner_image_agent_check"),
+          "div_add_edit_banner_image_agent_check",
+          "delete",
+          "freeform"
+        );
+        await window.wait(1000);
+
+        // scroll the next section into view
+        document.querySelector("#edit_banner_image_button").scrollIntoView({ behavior: "smooth" });
+      }
+    },
+    { attributes: true }
+  );
+});
+
+agentCheckBannerImageDivObserver.observe(agentCheckBannerImageDiv, {
+  childList: true,
+  subtree: true,
+  characterData: true,
+});

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -322,7 +322,7 @@ $("#advanced-start-over-button").on("click", async () => {
 
 // Action when user click on "Import image" button for banner image
 $("#button-import-banner-image").click(async () => {
-  console.log("THis is happening?")
+  console.log("THis is happening?");
   $("#para-dataset-banner-image-status").html("");
   let filePaths = await window.electron.ipcRenderer.invoke("open-file-dialog-import-banner-image");
   window.handleSelectedBannerImage(filePaths, "freeform");

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -231,6 +231,16 @@ $("#advanced-start-over-button").on("click", async () => {
     ).children[0].children[0].style.display = "block";
     document.getElementById("input-manifest-local-folder-dataset").placeholder = "Browse here";
 
+    // hide the pennsieve agent check section
+    document.getElementById("advanced-features-manifest-generation-pennsieve-agent-check").classList.add("hidden");
+    // hide the pull manifest information button's div
+    document.getElementById("div-btn-pull-ds-manifest").classList.add("hidden");
+    // set the dataset text to none
+    document.querySelector("#bf_dataset_create_manifest").textContent = "None";
+    // hide the confirm button 
+    document.querySelector("#btn-confirm-dataset-manifest-page").classList.add("hidden")
+
+
     // Hide the all sub-questions for generating manifest
     document.getElementById("Question-prepare-manifest-2").classList.remove("show");
     document.getElementById("Question-prepare-manifest-2").classList.remove("prev");

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -322,6 +322,7 @@ $("#advanced-start-over-button").on("click", async () => {
 
 // Action when user click on "Import image" button for banner image
 $("#button-import-banner-image").click(async () => {
+  console.log("THis is happening?")
   $("#para-dataset-banner-image-status").html("");
   let filePaths = await window.electron.ipcRenderer.invoke("open-file-dialog-import-banner-image");
   window.handleSelectedBannerImage(filePaths, "freeform");

--- a/src/renderer/src/scripts/advanced-features/advanced_features.js
+++ b/src/renderer/src/scripts/advanced-features/advanced_features.js
@@ -322,7 +322,6 @@ $("#advanced-start-over-button").on("click", async () => {
 
 // Action when user click on "Import image" button for banner image
 $("#button-import-banner-image").click(async () => {
-  console.log("THis is happening?");
   $("#para-dataset-banner-image-status").html("");
   let filePaths = await window.electron.ipcRenderer.invoke("open-file-dialog-import-banner-image");
   window.handleSelectedBannerImage(filePaths, "freeform");
@@ -354,9 +353,6 @@ document.querySelector("#btn-confirm-dataset-manifest-page").addEventListener("c
   if (!agentCheckSuccessful) {
     return;
   }
-
-  // show the btn-pull-ds-manifest button
-  // document.querySelector("#div-btn-pull-ds-manifest").classList.remove("hidden");
 
   // scroll to the button
   document.querySelector("#div-btn-pull-ds-manifest").scrollIntoView({ behavior: "smooth" });

--- a/src/renderer/src/scripts/manage-dataset/manage-dataset.js
+++ b/src/renderer/src/scripts/manage-dataset/manage-dataset.js
@@ -2233,6 +2233,7 @@ $("#save-banner-image").click((event) => {
 });
 
 window.showCurrentBannerImage = async () => {
+  console.log("Show current banner image called?");
   let selectedBfAccount = window.defaultBfAccount;
   let selectedBfDataset = window.defaultBfDataset;
 

--- a/src/renderer/src/scripts/metadata-files/manifest.js
+++ b/src/renderer/src/scripts/metadata-files/manifest.js
@@ -119,6 +119,8 @@ $(document).ready(async function () {
   $("#bf_dataset_create_manifest").on("DOMSubtreeModified", () => {
     if ($("#bf_dataset_create_manifest").text().trim() !== "None") {
       $("#div-check-bf-create-manifest").css("display", "flex");
+      document.querySelector("#btn-confirm-dataset-manifest-page").classList.remove("hidden")
+
       $($("#div-check-bf-create-manifest").children()[0]).show();
     } else {
       $("#div-check-bf-create-manifest").css("display", "none");

--- a/src/renderer/src/scripts/metadata-files/manifest.js
+++ b/src/renderer/src/scripts/metadata-files/manifest.js
@@ -119,7 +119,7 @@ $(document).ready(async function () {
   $("#bf_dataset_create_manifest").on("DOMSubtreeModified", () => {
     if ($("#bf_dataset_create_manifest").text().trim() !== "None") {
       $("#div-check-bf-create-manifest").css("display", "flex");
-      document.querySelector("#btn-confirm-dataset-manifest-page").classList.remove("hidden")
+      document.querySelector("#btn-confirm-dataset-manifest-page").classList.remove("hidden");
 
       $($("#div-check-bf-create-manifest").children()[0]).show();
     } else {

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -532,7 +532,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
   try {
     // Step 0: abort if the background services are already running
     if (useGlobalStore.getState()["pennsieveAgentCheckInProgress"] === true) {
-  console.log("oops")
+      console.log("oops");
 
       return false;
     }
@@ -548,7 +548,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
         "An internet connection is required to upload to Pennsieve. Please connect to the internet and try again."
       );
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
-  console.log("oops")
+      console.log("oops");
 
       return false;
     }
@@ -562,7 +562,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
       const pennsieveAgentDownloadURL = await getPlatformSpecificAgentDownloadURL();
       setPennsieveAgentDownloadURL(pennsieveAgentDownloadURL);
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
-  console.log("oops")
+      console.log("oops");
 
       return false;
     }
@@ -583,7 +583,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
       const emessage = userErrorMessage(error);
       setPennsieveAgentOutputErrorMessage(emessage);
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
-  console.log("oops")
+      console.log("oops");
 
       return false;
     }
@@ -599,7 +599,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
         "Please check the Pennsieve Agent logs for more information."
       );
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
-      console.log("oops")
+      console.log("oops");
 
       return false;
     }
@@ -616,7 +616,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
         emessage
       );
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
-      console.log("oops")
+      console.log("oops");
 
       return false;
     }
@@ -626,7 +626,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
       setPennsieveAgentDownloadURL(pennsieveAgentDownloadURL);
       setPennsieveAgentOutOfDate(usersPennsieveAgentVersion, latestPennsieveAgentVersion);
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
-      console.log("oops")
+      console.log("oops");
 
       return false;
     }

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -532,6 +532,8 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
   try {
     // Step 0: abort if the background services are already running
     if (useGlobalStore.getState()["pennsieveAgentCheckInProgress"] === true) {
+  console.log("oops")
+
       return false;
     }
     // Reset the background services state in the store and set the checks in progress
@@ -546,6 +548,8 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
         "An internet connection is required to upload to Pennsieve. Please connect to the internet and try again."
       );
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
+  console.log("oops")
+
       return false;
     }
 
@@ -558,6 +562,8 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
       const pennsieveAgentDownloadURL = await getPlatformSpecificAgentDownloadURL();
       setPennsieveAgentDownloadURL(pennsieveAgentDownloadURL);
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
+  console.log("oops")
+
       return false;
     }
 
@@ -577,6 +583,8 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
       const emessage = userErrorMessage(error);
       setPennsieveAgentOutputErrorMessage(emessage);
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
+  console.log("oops")
+
       return false;
     }
 
@@ -591,6 +599,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
         "Please check the Pennsieve Agent logs for more information."
       );
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
+      console.log("oops")
 
       return false;
     }
@@ -607,6 +616,7 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
         emessage
       );
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
+      console.log("oops")
 
       return false;
     }
@@ -616,6 +626,8 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
       setPennsieveAgentDownloadURL(pennsieveAgentDownloadURL);
       setPennsieveAgentOutOfDate(usersPennsieveAgentVersion, latestPennsieveAgentVersion);
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
+      console.log("oops")
+
       return false;
     }
 

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -2593,7 +2593,7 @@ function populateDatasetDropdownCurate(datasetDropdown, datasetList) {
 // ///////////////////////////////END OF NEW CURATE UI CODE ADAPTATION ///////////////////////////////////////////////////
 
 const metadataDatasetlistChange = () => {
-  console.log("This is called")
+  console.log("This is called");
   $("#bf-dataset-subtitle").val("");
   $("#para-dataset-banner-image-status").html("");
   window.showCurrentSubtitle();
@@ -4962,7 +4962,7 @@ document.querySelectorAll(".file-import-container").forEach((fileImportContainer
 //path: array
 //curationMode: string (guided-moded) (freeform)
 window.handleSelectedBannerImage = async (path, curationMode) => {
-  console.log("This is called")
+  console.log("This is called");
   let imgContainer = "";
   let imgHolder = "";
   let paraImagePath = "";

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -2593,6 +2593,7 @@ function populateDatasetDropdownCurate(datasetDropdown, datasetList) {
 // ///////////////////////////////END OF NEW CURATE UI CODE ADAPTATION ///////////////////////////////////////////////////
 
 const metadataDatasetlistChange = () => {
+  console.log("This is called")
   $("#bf-dataset-subtitle").val("");
   $("#para-dataset-banner-image-status").html("");
   window.showCurrentSubtitle();
@@ -4961,6 +4962,7 @@ document.querySelectorAll(".file-import-container").forEach((fileImportContainer
 //path: array
 //curationMode: string (guided-moded) (freeform)
 window.handleSelectedBannerImage = async (path, curationMode) => {
+  console.log("This is called")
   let imgContainer = "";
   let imgHolder = "";
   let paraImagePath = "";

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -562,8 +562,6 @@ window.checkPennsieveAgent = async (pennsieveAgentStatusDivId) => {
       const pennsieveAgentDownloadURL = await getPlatformSpecificAgentDownloadURL();
       setPennsieveAgentDownloadURL(pennsieveAgentDownloadURL);
       abortPennsieveAgentCheck(pennsieveAgentStatusDivId);
-      console.log("oops");
-
       return false;
     }
 

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -4962,7 +4962,7 @@ document.querySelectorAll(".file-import-container").forEach((fileImportContainer
 //path: array
 //curationMode: string (guided-moded) (freeform)
 window.handleSelectedBannerImage = async (path, curationMode) => {
-  console.log("This is called");
+  console.log("This is called - handle selected banner image");
   let imgContainer = "";
   let imgHolder = "";
   let paraImagePath = "";
@@ -4978,6 +4978,7 @@ window.handleSelectedBannerImage = async (path, curationMode) => {
     cropperOptions = window.guidedCropOptions;
   }
   if (curationMode === "freeform") {
+    console.log("Here specifically");
     cropperOptions = window.cropOptions;
     paraImagePath = "#para-path-image";
     saveBannerImage = "#save-banner-image";

--- a/src/renderer/src/scripts/others/tab-effects.js
+++ b/src/renderer/src/scripts/others/tab-effects.js
@@ -2067,6 +2067,7 @@ window.transitionSubQuestionsButton = async (ev, currentDiv, parentDiv, button, 
 };
 
 window.transitionFreeFormMode = async (ev, currentDiv, parentDiv, button, category) => {
+  console.log("Transition free form mode called?");
   let continueProgressRC = true;
   let continueProgressDD = true;
 
@@ -2343,6 +2344,21 @@ window.transitionFreeFormMode = async (ev, currentDiv, parentDiv, button, catego
       document.getElementById("dd-select-pennsieve-dataset").style.display = "none";
     }
   }
+
+  if (ev.getAttribute("data-next") === "div_add_edit_banner_image_agent_check") {
+    // show the Pennsieve Agent slot
+    const pennsieveAgentCheckDivId = "advanced-features-banner-image-pennsieve-agent-check";
+    let pennsieveAgentCheckDiv = document.querySelector(`#${pennsieveAgentCheckDivId}`);
+
+    // start agent check
+    try {
+      pennsieveAgentCheckDiv.classList.remove("hidden");
+      // Check to make sure the Pennsieve agent is installed
+      window.checkPennsieveAgent(pennsieveAgentCheckDivId);
+    } catch (e) {
+      console.error("Error with agent" + e);
+    }
+  }
   // hide related previous divs
   hidePrevDivs(currentDiv, category);
   // display the target tab (data-next tab)
@@ -2356,7 +2372,10 @@ window.transitionFreeFormMode = async (ev, currentDiv, parentDiv, button, catego
         let label = document.querySelector("#Question-prepare-manifest-5 label:first-of-type");
         label.scrollIntoView({ behavior: "smooth" });
       } // auto-scroll to bottom of div
-      else if (ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections") {
+      else if (
+        ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections" &&
+        ev.getAttribute("data-next") !== "div_add_edit_banner"
+      ) {
         document.getElementById(parentDiv).scrollTop =
           document.getElementById(parentDiv).scrollHeight;
       }
@@ -2371,7 +2390,10 @@ window.transitionFreeFormMode = async (ev, currentDiv, parentDiv, button, catego
       setTimeout(function () {
         $(ev).siblings().hide();
         // auto-scroll to bottom of div
-        if (ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections") {
+        if (
+          ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections" &&
+          ev.getAttribute("data-next") !== "div_add_edit_banner"
+        ) {
           document.getElementById(parentDiv).scrollTop =
             document.getElementById(parentDiv).scrollHeight;
         }
@@ -2380,7 +2402,10 @@ window.transitionFreeFormMode = async (ev, currentDiv, parentDiv, button, catego
     setTimeout(function () {
       $(ev).hide();
       // auto-scroll to bottom of div
-      if (ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections") {
+      if (
+        ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections" &&
+        ev.getAttribute("data-next") !== "div_add_edit_banner"
+      ) {
         document.getElementById(parentDiv).scrollTop =
           document.getElementById(parentDiv).scrollHeight;
       }
@@ -2418,7 +2443,10 @@ window.transitionFreeFormMode = async (ev, currentDiv, parentDiv, button, catego
   }
 
   // auto-scroll to bottom of div
-  if (ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections") {
+  if (
+    ev.getAttribute("data-next") !== "Question-prepare-dd-4-sections" &&
+    ev.getAttribute("data-next") !== "div_add_edit_banner"
+  ) {
     document.getElementById(parentDiv).scrollTop = document.getElementById(parentDiv).scrollHeight;
   }
 

--- a/src/renderer/src/sections/advanced-features/advanced_features.html
+++ b/src/renderer/src/sections/advanced-features/advanced_features.html
@@ -863,14 +863,21 @@
                 class="hidden"
                 id="advanced-features-manifest-generation-pennsieve-agent-check"
               ></div>
-              <div id="div-btn-pull-ds-manifest" 
-                  style="flex-direction: row; justify-content: center; margin: 25px auto; display: flex;" 
-                  class="hidden">
+              <div
+                id="div-btn-pull-ds-manifest"
+                style="
+                  flex-direction: row;
+                  justify-content: center;
+                  margin: 25px auto;
+                  display: flex;
+                "
+                class="hidden"
+              >
                 <div
-                data-component-type="generic-button"
-                data-text="Pull Manifest Information"
-                id="btn-pull-ds-manifest"
-              ></div>
+                  data-component-type="generic-button"
+                  data-text="Pull Manifest Information"
+                  id="btn-pull-ds-manifest"
+                ></div>
               </div>
             </div>
 

--- a/src/renderer/src/sections/advanced-features/advanced_features.html
+++ b/src/renderer/src/sections/advanced-features/advanced_features.html
@@ -288,6 +288,17 @@
 
         <div
           class="individual-question manage-dataset"
+          id="div_add_edit_banner_image_agent_check"
+          data-next="div_add_edit_banner"
+        >
+          <div
+            data-component-type="pennsieve-agent-check-display"
+            id="advanced-features-banner-image-pennsieve-agent-check"
+          ></div>
+        </div>
+
+        <div
+          class="individual-question manage-dataset"
           id="div_add_edit_banner"
           style="height: auto"
         >

--- a/src/renderer/src/sections/advanced-features/advanced_features.html
+++ b/src/renderer/src/sections/advanced-features/advanced_features.html
@@ -863,25 +863,14 @@
                 class="hidden"
                 id="advanced-features-manifest-generation-pennsieve-agent-check"
               ></div>
-              <div style="flex-direction: row; justify-content: center; margin: 25px auto">
-                <button
-                  id="btn-pull-ds-manifest"
-                  style="
-                    border: none !important;
-                    border-radius: 4px;
-                    margin: 0.5rem auto;
-                    width: 110px;
-                    height: 35px;
-                    background: var(--color-light-green);
-                    color: #fff;
-                    font-size: 14px;
-                    font-weight: 600;
-                    padding-left: 9px;
-                  "
-                  class="hidden btn_animated"
-                >
-                  Pull Manifest Information
-                </button>
+              <div id="div-btn-pull-ds-manifest" 
+                  style="flex-direction: row; justify-content: center; margin: 25px auto; display: flex;" 
+                  class="hidden">
+                <div
+                data-component-type="generic-button"
+                data-text="Pull Manifest Information"
+                id="btn-pull-ds-manifest"
+              ></div>
               </div>
             </div>
 

--- a/src/renderer/src/sections/advanced-features/advanced_features.html
+++ b/src/renderer/src/sections/advanced-features/advanced_features.html
@@ -821,8 +821,7 @@
                 class="btn-confirm-ds-selection"
               >
                 <button
-                  onclick="window.generateManifestFolderLocallyForEdit(this)"
-                  id="btn-pull-ds-manifest"
+                  id="btn-confirm-dataset-manifest-page"
                   class="btn_animated"
                   style="
                     border: none !important;
@@ -857,6 +856,31 @@
                   "
                 >
                   Fake confirm
+                </button>
+              </div>
+              <div
+                data-component-type="pennsieve-agent-check-display"
+                class="hidden"
+                id="advanced-features-manifest-generation-pennsieve-agent-check"
+              ></div>
+              <div style="flex-direction: row; justify-content: center; margin: 25px auto">
+                <button
+                  id="btn-pull-ds-manifest"
+                  style="
+                    border: none !important;
+                    border-radius: 4px;
+                    margin: 0.5rem auto;
+                    width: 110px;
+                    height: 35px;
+                    background: var(--color-light-green);
+                    color: #fff;
+                    font-size: 14px;
+                    font-weight: 600;
+                    padding-left: 9px;
+                  "
+                  class="hidden btn_animated"
+                >
+                  Pull Manifest Information
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary by Sourcery

Fix the Pennsieve agent check to correctly identify uninstalled and not running states. Enhance error handling and UI feedback for Pennsieve agent operations, including adding mutation observers and updating error messages with documentation links.

Bug Fixes:
- Fix the Pennsieve agent check in advanced features to correctly differentiate between uninstalled and not running agent states.

Enhancements:
- Improve error handling and logging for Pennsieve agent operations, including stopping, deleting database files, and restarting the agent.
- Add mutation observers to monitor changes in the Pennsieve agent check status and update the UI accordingly.
- Enhance the user interface to provide clearer feedback on the status of the Pennsieve agent, including messages for installation status and error conditions.

Documentation:
- Update the Pennsieve agent error message display to include a link to the SODA documentation for troubleshooting.