### PR TITLE
feat: guest contributor support in SDOA's end to end curation mode

### DIFF
--- a/.github/workflows/Build-and-deploy-linux.yml
+++ b/.github/workflows/Build-and-deploy-linux.yml
@@ -7,7 +7,7 @@ on:
       - main
       - staging
       - pre-staging
-      - folder-build
+      - guest-contributor-fixes
 
 jobs:
   deploy-on-linux:

--- a/.github/workflows/Build-and-deploy-win.yml
+++ b/.github/workflows/Build-and-deploy-win.yml
@@ -7,7 +7,7 @@ on:
       - main
       - staging
       - pre-staging
-      - folder-build
+      - guest-contributor-fixes
 
 jobs:
   deploy-on-windows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Feature Additions:
 
-- SODA will notify users if it is determined that a network setting may be preventing communication to the Pennsieve platform. 
-- The `Prepare Dataset Step-by-Step` feature allows users to resume curating a dataset even when that dataset saved files that have since been deleted from the computer. 
-
+- SODA will notify users if it is determined that a network setting may be preventing communication to the Pennsieve platform.
+- The `Prepare Dataset Step-by-Step` feature allows users to resume curating a dataset even when that dataset saved files that have since been deleted from the computer.
 
 ## v15.2.3 - 2024-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to SODA will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v15.3.0 - 2024-12-03
+
+## Feature Additions:
+
+- SODA will notify users if it is determined that a network setting may be preventing communication to the Pennsieve platform. 
+- The `Prepare Dataset Step-by-Step` feature allows users to resume curating a dataset even when that dataset saved files that have since been deleted from the computer. 
+
+
 ## v15.2.3 - 2024-11-20
 
 ## Bug Fixes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soda-for-sparc",
   "procductName": "SODA for SPARC",
-  "version": "15.2.4-beta",
+  "version": "15.3.0-beta",
   "description": "Keep Calm and Curate",
   "main": "./out/main/index.js",
   "author": "SODA Team",

--- a/src/pyflask/manageDatasets/manage_datasets.py
+++ b/src/pyflask/manageDatasets/manage_datasets.py
@@ -337,7 +337,8 @@ def bf_dataset_account(accountname):
             r = requests.get(f"{PENNSIEVE_URL}/datasets/{str(selected_dataset_id)}/role", headers=create_request_headers(get_access_token()))
             r.raise_for_status()
             user_role = r.json()["role"]
-            if user_role not in ["viewer", "editor"]:
+            namespace_logger.info(f"User role: {user_role}")
+            if user_role not in ["viewer"]:
                 store.append(
                     {"id": selected_dataset_id, "name": dataset['name'], "role": user_role, "intId": dataset["intId"]}
                 )
@@ -358,6 +359,7 @@ def bf_dataset_account(accountname):
     [t.join() for t in threads]
 
     sorted_bf_datasets = sorted(store, key=lambda k: k["name"].upper())
+    namespace_logger.info(f"Sorted datasets: {sorted_bf_datasets}")
     return {"datasets": sorted_bf_datasets}
 
 def get_username(accountname):

--- a/src/pyflask/organizeDatasets/organize_datasets.py
+++ b/src/pyflask/organizeDatasets/organize_datasets.py
@@ -1157,13 +1157,16 @@ def import_pennsieve_dataset(soda_json_structure, requested_sparc_only=True):
     # START
     start = timer()
 
-    # check that the Pennsieve dataset is valid
-    try:
-        bf_dataset_name = soda_json_structure["bf-dataset-selected"]["dataset-name"]
-    except Exception as e:
-        raise e
+    if "digital-metadata" in soda_json_structure and "pennsieve-dataset-id" in soda_json_structure["digital-metadata"]:
+        selected_dataset_id = soda_json_structure["digital-metadata"]["pennsieve-dataset-id"]
+    else:
+        # check that the Pennsieve dataset is valid
+        try:
+            bf_dataset_name = soda_json_structure["bf-dataset-selected"]["dataset-name"]
+        except Exception as e:
+            raise e
 
-    selected_dataset_id = get_dataset_id(bf_dataset_name)
+        selected_dataset_id = get_dataset_id(bf_dataset_name)
 
     # check that the user has permission to edit this dataset
     try:

--- a/src/pyflask/permissions/permissions.py
+++ b/src/pyflask/permissions/permissions.py
@@ -29,4 +29,4 @@ def has_edit_permissions(ps_or_token, selected_dataset_id):
     except Exception as e:
         abort(500, "Could not get permissions for this dataset.")
 
-    return role in ["owner", "manager"]  
+    return role in ["owner", "manager", "editor"]  

--- a/src/pyflask/startup/minimumApiVersion.py
+++ b/src/pyflask/startup/minimumApiVersion.py
@@ -8,7 +8,7 @@ def get_api_version():
     """
 
 
-    return {'version': os.getenv('API_VERSION', "15.2.4-beta")}
+    return {'version': os.getenv('API_VERSION', "15.3.0-beta")}
 
 
 

--- a/src/renderer/src/scripts/globals.js
+++ b/src/renderer/src/scripts/globals.js
@@ -2187,11 +2187,11 @@ const get_api_key = (login, password, key_name) => {
   });
 };
 
-window.isWorkspaceGuest = async  () => {
+window.isWorkspaceGuest = async () => {
   let userInfo = await api.getUserInformation();
   let currentWorkspace = userInfo["preferredOrganization"];
 
-  let orgResponse; 
+  let orgResponse;
   try {
     orgResponse = await client.get(`user/organizations`, {
       params: {
@@ -2204,9 +2204,11 @@ window.isWorkspaceGuest = async  () => {
   }
 
   // get the current workspace by matching the id
-  let currentWorkspaceObj = orgResponse.data.organizations.filter(org => org.organization.id === currentWorkspace)[0]
-  return currentWorkspaceObj.isGuest
-}
+  let currentWorkspaceObj = orgResponse.data.organizations.filter(
+    (org) => org.organization.id === currentWorkspace
+  )[0];
+  return currentWorkspaceObj.isGuest;
+};
 
 export {
   currentConTable,
@@ -2215,5 +2217,5 @@ export {
   initializeBootstrapSelect,
   updateDatasetList,
   bfAccountOptions,
-  get_api_key
+  get_api_key,
 };

--- a/src/renderer/src/scripts/globals.js
+++ b/src/renderer/src/scripts/globals.js
@@ -2187,6 +2187,27 @@ const get_api_key = (login, password, key_name) => {
   });
 };
 
+window.isWorkspaceGuest = async  () => {
+  let userInfo = await api.getUserInformation();
+  let currentWorkspace = userInfo["preferredOrganization"];
+
+  let orgResponse; 
+  try {
+    orgResponse = await client.get(`user/organizations`, {
+      params: {
+        selected_account: window.defaultBfAccount,
+      },
+    });
+  } catch (error) {
+    clientError(error);
+    // TODO: Handle error here
+  }
+
+  // get the current workspace by matching the id
+  let currentWorkspaceObj = orgResponse.data.organizations.filter(org => org.organization.id === currentWorkspace)[0]
+  return currentWorkspaceObj.isGuest
+}
+
 export {
   currentConTable,
   showHideDropdownButtons,
@@ -2194,5 +2215,5 @@ export {
   initializeBootstrapSelect,
   updateDatasetList,
   bfAccountOptions,
-  get_api_key,
+  get_api_key
 };

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -6289,8 +6289,9 @@ window.openPage = async (targetPageID) => {
     }
 
     if (targetPageID === "guided-designate-permissions-tab") {
+      console.log("In permissions tab")
       let isGuest = await window.isWorkspaceGuest();
-      if (isGuest) return;
+      if (!isGuest) {
       // Get the users that can be granted permissions
       const usersReq = await client.get(
         `manage_datasets/ps_get_users?selected_account=${window.defaultBfAccount}`
@@ -6440,6 +6441,7 @@ window.openPage = async (targetPageID) => {
 
       renderPermissionsTable();
       guidedResetUserTeamPermissionsDropdowns();
+      }
     }
 
     if (targetPageID === "guided-assign-license-tab") {
@@ -6961,6 +6963,7 @@ window.openPage = async (targetPageID) => {
 
     // Set the last opened page and save it
     window.sodaJSONObj["page-before-exit"] = targetPageID;
+    console.log("About to save progress")
     await guidedSaveProgress();
   } catch (error) {
     const eMessage = userErrorMessage(error);
@@ -13950,6 +13953,8 @@ const guidedCreateOrRenameDataset = async (bfAccount, datasetName) => {
 };
 
 const guidedAddDatasetSubtitle = async (bfAccount, datasetName, datasetSubtitle) => {
+  let isGuest = await window.isWorkspaceGuest()
+  if (isGuest) return;
   document.getElementById("guided-dataset-subtitle-upload-tr").classList.remove("hidden");
   const datasetSubtitleUploadText = document.getElementById("guided-dataset-subtitle-upload-text");
   datasetSubtitleUploadText.innerHTML = "Adding dataset subtitle...";
@@ -14032,6 +14037,8 @@ const guidedAddDatasetDescription = async (
   dataCollection,
   dataConclusion
 ) => {
+  let isGuest = await window.isWorkspaceGuest()
+  if (isGuest) return;
   document.getElementById("guided-dataset-description-upload-tr").classList.remove("hidden");
   const datasetDescriptionUploadText = document.getElementById(
     "guided-dataset-description-upload-text"
@@ -14111,6 +14118,8 @@ const guidedAddDatasetDescription = async (
 };
 
 const uploadValidBannerImage = async (bfAccount, datasetName, bannerImagePath) => {
+  let isGuest = await window.isWorkspaceGuest()
+  if (isGuest) return;
   document.getElementById("guided-dataset-banner-image-upload-tr").classList.remove("hidden");
   const datasetBannerImageUploadText = document.getElementById(
     "guided-dataset-banner-image-upload-text"
@@ -14217,6 +14226,8 @@ const guidedAddDatasetBannerImage = async (bfAccount, datasetName, bannerImagePa
   await uploadValidBannerImage(bfAccount, datasetName, bannerImagePath);
 };
 const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) => {
+  let isGuest = await window.isWorkspaceGuest()
+  if (isGuest) return;
   document.getElementById("guided-dataset-license-upload-tr").classList.remove("hidden");
   const datasetLicenseUploadText = document.getElementById("guided-dataset-license-upload-text");
   datasetLicenseUploadText.innerHTML = "Adding dataset license...";
@@ -14292,6 +14303,8 @@ const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) =
 };
 
 const guidedAddDatasetTags = async (bfAccount, datasetName, tags) => {
+  let isGuest = await window.isWorkspaceGuest()
+  if (isGuest) return;
   document.getElementById("guided-dataset-tags-upload-tr").classList.remove("hidden");
   const datasetTagsUploadText = document.getElementById("guided-dataset-tags-upload-text");
   datasetTagsUploadText.innerHTML = "Adding dataset tags...";

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -8051,6 +8051,8 @@ window.guidedResumeProgress = async (datasetNameToResume) => {
     let guest = await window.isWorkspaceGuest();
     if (!guest) {
       guidedUnSkipPage("guided-designate-permissions-tab");
+    } else {
+      guidedSkipPage("guided-designate-permissions-tab");
     }
 
     // Skip this page incase it was not skipped in a previous session

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -15583,6 +15583,13 @@ const editPennsieveMetadata = async () => {
     return;
   }
 
+  const guidedBfAccount = window.defaultBfAccount;
+  const guidedDatasetName = window.sodaJSONObj["digital-metadata"]["name"];
+  const guidedDatasetSubtitle = window.sodaJSONObj["digital-metadata"]["subtitle"];
+  const guidedBannerImagePath = window.sodaJSONObj["digital-metadata"]?.["banner-image-path"];
+  const guidedLicense = window.sodaJSONObj["digital-metadata"]["license"];
+  const guidedTags = window.sodaJSONObj["digital-metadata"]["dataset-tags"];
+
   await guidedAddDatasetSubtitle(guidedBfAccount, guidedDatasetName, guidedDatasetSubtitle);
   await guidedAddDatasetDescription(
     guidedBfAccount,

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -15609,6 +15609,8 @@ const guidedPennsieveDatasetUpload = async () => {
       "guided-div-pennsieve-metadata-pennsieve-genration-status-table"
     );
 
+    let guest = await window.isWorkspaceGuest();
+
     // Create the dataset on Pennsieve
     await guidedCreateOrRenameDataset(guidedBfAccount, guidedDatasetName);
 
@@ -15623,8 +15625,10 @@ const guidedPennsieveDatasetUpload = async () => {
     await guidedAddDatasetBannerImage(guidedBfAccount, guidedDatasetName, guidedBannerImagePath);
     await guidedAddDatasetLicense(guidedBfAccount, guidedDatasetName, guidedLicense);
     await guidedAddDatasetTags(guidedBfAccount, guidedDatasetName, guidedTags);
-    await guidedAddUserPermissions(guidedBfAccount, guidedDatasetName, guidedUsers);
-    await guidedAddTeamPermissions(guidedBfAccount, guidedDatasetName, guidedTeams);
+    if (!guest) {
+      await guidedAddUserPermissions(guidedBfAccount, guidedDatasetName, guidedUsers);
+      await guidedAddTeamPermissions(guidedBfAccount, guidedDatasetName, guidedTeams);
+    }
 
     hideDatasetMetadataGenerationTableRows("pennsieve");
 

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -5231,7 +5231,19 @@ window.openPage = async (targetPageID) => {
       if (pageNeedsUpdateFromPennsieve("guided-name-subtitle-tab")) {
         // Show the loading page while the page's data is being fetched from Pennsieve
         setPageLoadingState(true);
+
         try {
+          // get the dataset name from Pennsieve
+          const datasetResponse = await api.getDatasetInformation(
+            window.defaultBfAccount,
+            window.sodaJSONObj["digital-metadata"]["pennsieve-dataset-id"]
+          );
+          console.log(datasetResponse);
+          let datasetName = datasetResponse["content"]["name"];
+          // Save the dataset name to the JSON and add it to the input
+          window.sodaJSONObj["digital-metadata"]["name"] = datasetName;
+          setGuidedDatasetName(datasetName);
+
           //Try to get the dataset name from Pennsieve
           //If the request fails, the subtitle input will remain blank
           const datasetSubtitle = await api.getDatasetSubtitle(

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -5838,7 +5838,7 @@ window.openPage = async (targetPageID) => {
           let metadata_import = await client.get(`/prepare_metadata/import_metadata_file`, {
             params: {
               selected_account: window.defaultBfAccount,
-              selected_dataset: window.sodaJSONObj["bf-dataset-selected"]["dataset-name"],
+              selected_dataset: window.sodaJSONObj["digital-metadata"]["pennsieve-dataset-id"],
               file_type: "dataset_description.xlsx",
             },
           });
@@ -13428,7 +13428,8 @@ const handleMultipleSubSectionDisplay = async (controlledSectionID) => {
               {
                 params: {
                   selected_account: window.defaultBfAccount,
-                  selected_dataset: window.sodaJSONObj["bf-dataset-selected"]["dataset-name"],
+                  selected_dataset:
+                    window.sodaJSONObj["bf-dataset-selected"]["pennsieve-dataset-id"],
                   file_type: "dataset_description.xlsx",
                 },
               }

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -6289,158 +6289,158 @@ window.openPage = async (targetPageID) => {
     }
 
     if (targetPageID === "guided-designate-permissions-tab") {
-      console.log("In permissions tab")
+      console.log("In permissions tab");
       let isGuest = await window.isWorkspaceGuest();
       if (!isGuest) {
-      // Get the users that can be granted permissions
-      const usersReq = await client.get(
-        `manage_datasets/ps_get_users?selected_account=${window.defaultBfAccount}`
-      );
-      const usersThatCanBeGrantedPermissions = usersReq.data.users;
-
-      // Get the teams that can be granted permissions
-      // Note: This is in a try catch because guest accounts do not have access to the teams endpoint
-      // so the request will fail and teamsThatCanBeGrantedPermissions will remain an empty array
-      let teamsThatCanBeGrantedPermissions = [];
-      try {
-        const teamsReq = await client.get(
-          `manage_datasets/ps_get_teams?selected_account=${window.defaultBfAccount}`
+        // Get the users that can be granted permissions
+        const usersReq = await client.get(
+          `manage_datasets/ps_get_users?selected_account=${window.defaultBfAccount}`
         );
-        teamsThatCanBeGrantedPermissions = window.getSortedTeamStrings(teamsReq.data.teams);
-      } catch (error) {
-        const emessage = userErrorMessage(error);
-      }
+        const usersThatCanBeGrantedPermissions = usersReq.data.users;
 
-      // Reset the dropdown with the new users and teams
-      guidedAddUsersAndTeamsToDropdown(
-        usersThatCanBeGrantedPermissions,
-        teamsThatCanBeGrantedPermissions
-      );
-
-      if (pageNeedsUpdateFromPennsieve("guided-designate-permissions-tab")) {
-        // Show the loading page while the page's data is being fetched from Pennsieve
-        setPageLoadingState(true);
+        // Get the teams that can be granted permissions
+        // Note: This is in a try catch because guest accounts do not have access to the teams endpoint
+        // so the request will fail and teamsThatCanBeGrantedPermissions will remain an empty array
+        let teamsThatCanBeGrantedPermissions = [];
         try {
-          let sparcUsersDivided = [];
-
-          //sparc users results needs to be formatted
-          usersThatCanBeGrantedPermissions.forEach((element) => {
-            //first two elements of this array will just be an email with no name
-            sparcUsersDivided.push(element.split(" !|**|!"));
-          });
-
-          const permissions = await api.getDatasetPermissions(
-            window.defaultBfAccount,
-            window.sodaJSONObj["digital-metadata"]["pennsieve-dataset-id"],
-            false
+          const teamsReq = await client.get(
+            `manage_datasets/ps_get_teams?selected_account=${window.defaultBfAccount}`
           );
-
-          //Filter out the integration user
-          const filteredPermissions = permissions.filter((permission) => {
-            return !permission.includes("Integration User");
-          });
-
-          let partialUserDetails = [];
-          let finalTeamPermissions = [];
-          let piOwner = [];
-
-          //so check for PI owner as well
-          for (const userPermission of filteredPermissions) {
-            // Will include teams and users
-            let userRoleSplit = userPermission.split(",");
-            // Will look like:
-            // ['User: John Doe ', ' role: owner']
-            // need to split above
-            let nameSplit = userRoleSplit[0].split(":"); // will appear as ['Team', ' DRC Team']
-            let roleSplit = userRoleSplit[1].split(":"); // will appear as [' role', ' Viewer']
-            let userName = nameSplit[1].trim();
-            let userPermiss = roleSplit[1].trim();
-            let teamOrUser = nameSplit[0].trim().toLowerCase();
-
-            if (teamOrUser === "team") {
-              finalTeamPermissions.push({
-                UUID: userName,
-                permission: userPermiss,
-                teamString: userName,
-                permissionSource: "Pennsieve",
-                deleteFromPennsieve: false,
-              });
-            } else {
-              partialUserDetails.push({
-                permission: userPermiss,
-                userName: userName,
-              });
-            }
-          }
-          // After loop use the array of objects to find the UUID and email
-          let finalUserPermissions = [];
-
-          partialUserDetails.map((object) => {
-            sparcUsersDivided.forEach((element) => {
-              if (element[0].includes(object["userName"])) {
-                // name was found now get UUID
-                let userEmailSplit = element[0].split(" (");
-                if (object["permission"] === "owner") {
-                  //set for pi owner
-                  piOwner.push({
-                    UUID: object.permission,
-                    name: userEmailSplit[0],
-                    userString: element[0],
-                    permissionSource: "Pennsieve",
-                    deleteFromPennsieve: false,
-                  });
-                  //update PI owner key
-                } else {
-                  finalUserPermissions.push({
-                    UUID: element[1],
-                    permission: object.permission,
-                    userName: userEmailSplit[0],
-                    userString: element[0],
-                    permissonSource: "Pennsieve",
-                    deleteFromPennsieve: false,
-                  });
-                }
-              }
-            });
-          });
-
-          window.sodaJSONObj["digital-metadata"]["team-permissions"] = finalTeamPermissions;
-          window.sodaJSONObj["digital-metadata"]["user-permissions"] = finalUserPermissions;
-          window.sodaJSONObj["digital-metadata"]["pi-owner"] = piOwner[0];
-
-          window.sodaJSONObj["pages-fetched-from-pennsieve"].push(
-            "guided-designate-permissions-tab"
-          );
+          teamsThatCanBeGrantedPermissions = window.getSortedTeamStrings(teamsReq.data.teams);
         } catch (error) {
-          clientError(error);
-          const emessage = error.response.data.message;
-          await guidedShowOptionalRetrySwal(emessage, "guided-designate-permissions-tab");
-          // If the user chooses not to retry re-fetching the page data, mark the page as fetched
-          // so the the fetch does not occur again
-          window.sodaJSONObj["pages-fetched-from-pennsieve"].push(
-            "guided-designate-permissions-tab"
-          );
+          const emessage = userErrorMessage(error);
         }
-      }
 
-      //If the PI owner is empty, set the PI owner to the user that is currently curating
-      if (Object.keys(window.sodaJSONObj["digital-metadata"]["pi-owner"]).length === 0) {
-        //Get the user information of the user that is currently curating
-        const user = await api.getUserInformation();
+        // Reset the dropdown with the new users and teams
+        guidedAddUsersAndTeamsToDropdown(
+          usersThatCanBeGrantedPermissions,
+          teamsThatCanBeGrantedPermissions
+        );
 
-        const loggedInUserString = `${user["firstName"]} ${user["lastName"]} (${user["email"]})`;
-        const loggedInUserUUID = user["id"];
-        const loggedInUserName = `${user["firstName"]} ${user["lastName"]}`;
-        const loggedInUserPiObj = {
-          userString: loggedInUserString,
-          UUID: loggedInUserUUID,
-          name: loggedInUserName,
-        };
-        setGuidedDatasetPiOwner(loggedInUserPiObj);
-      }
+        if (pageNeedsUpdateFromPennsieve("guided-designate-permissions-tab")) {
+          // Show the loading page while the page's data is being fetched from Pennsieve
+          setPageLoadingState(true);
+          try {
+            let sparcUsersDivided = [];
 
-      renderPermissionsTable();
-      guidedResetUserTeamPermissionsDropdowns();
+            //sparc users results needs to be formatted
+            usersThatCanBeGrantedPermissions.forEach((element) => {
+              //first two elements of this array will just be an email with no name
+              sparcUsersDivided.push(element.split(" !|**|!"));
+            });
+
+            const permissions = await api.getDatasetPermissions(
+              window.defaultBfAccount,
+              window.sodaJSONObj["digital-metadata"]["pennsieve-dataset-id"],
+              false
+            );
+
+            //Filter out the integration user
+            const filteredPermissions = permissions.filter((permission) => {
+              return !permission.includes("Integration User");
+            });
+
+            let partialUserDetails = [];
+            let finalTeamPermissions = [];
+            let piOwner = [];
+
+            //so check for PI owner as well
+            for (const userPermission of filteredPermissions) {
+              // Will include teams and users
+              let userRoleSplit = userPermission.split(",");
+              // Will look like:
+              // ['User: John Doe ', ' role: owner']
+              // need to split above
+              let nameSplit = userRoleSplit[0].split(":"); // will appear as ['Team', ' DRC Team']
+              let roleSplit = userRoleSplit[1].split(":"); // will appear as [' role', ' Viewer']
+              let userName = nameSplit[1].trim();
+              let userPermiss = roleSplit[1].trim();
+              let teamOrUser = nameSplit[0].trim().toLowerCase();
+
+              if (teamOrUser === "team") {
+                finalTeamPermissions.push({
+                  UUID: userName,
+                  permission: userPermiss,
+                  teamString: userName,
+                  permissionSource: "Pennsieve",
+                  deleteFromPennsieve: false,
+                });
+              } else {
+                partialUserDetails.push({
+                  permission: userPermiss,
+                  userName: userName,
+                });
+              }
+            }
+            // After loop use the array of objects to find the UUID and email
+            let finalUserPermissions = [];
+
+            partialUserDetails.map((object) => {
+              sparcUsersDivided.forEach((element) => {
+                if (element[0].includes(object["userName"])) {
+                  // name was found now get UUID
+                  let userEmailSplit = element[0].split(" (");
+                  if (object["permission"] === "owner") {
+                    //set for pi owner
+                    piOwner.push({
+                      UUID: object.permission,
+                      name: userEmailSplit[0],
+                      userString: element[0],
+                      permissionSource: "Pennsieve",
+                      deleteFromPennsieve: false,
+                    });
+                    //update PI owner key
+                  } else {
+                    finalUserPermissions.push({
+                      UUID: element[1],
+                      permission: object.permission,
+                      userName: userEmailSplit[0],
+                      userString: element[0],
+                      permissonSource: "Pennsieve",
+                      deleteFromPennsieve: false,
+                    });
+                  }
+                }
+              });
+            });
+
+            window.sodaJSONObj["digital-metadata"]["team-permissions"] = finalTeamPermissions;
+            window.sodaJSONObj["digital-metadata"]["user-permissions"] = finalUserPermissions;
+            window.sodaJSONObj["digital-metadata"]["pi-owner"] = piOwner[0];
+
+            window.sodaJSONObj["pages-fetched-from-pennsieve"].push(
+              "guided-designate-permissions-tab"
+            );
+          } catch (error) {
+            clientError(error);
+            const emessage = error.response.data.message;
+            await guidedShowOptionalRetrySwal(emessage, "guided-designate-permissions-tab");
+            // If the user chooses not to retry re-fetching the page data, mark the page as fetched
+            // so the the fetch does not occur again
+            window.sodaJSONObj["pages-fetched-from-pennsieve"].push(
+              "guided-designate-permissions-tab"
+            );
+          }
+        }
+
+        //If the PI owner is empty, set the PI owner to the user that is currently curating
+        if (Object.keys(window.sodaJSONObj["digital-metadata"]["pi-owner"]).length === 0) {
+          //Get the user information of the user that is currently curating
+          const user = await api.getUserInformation();
+
+          const loggedInUserString = `${user["firstName"]} ${user["lastName"]} (${user["email"]})`;
+          const loggedInUserUUID = user["id"];
+          const loggedInUserName = `${user["firstName"]} ${user["lastName"]}`;
+          const loggedInUserPiObj = {
+            userString: loggedInUserString,
+            UUID: loggedInUserUUID,
+            name: loggedInUserName,
+          };
+          setGuidedDatasetPiOwner(loggedInUserPiObj);
+        }
+
+        renderPermissionsTable();
+        guidedResetUserTeamPermissionsDropdowns();
       }
     }
 
@@ -6963,7 +6963,7 @@ window.openPage = async (targetPageID) => {
 
     // Set the last opened page and save it
     window.sodaJSONObj["page-before-exit"] = targetPageID;
-    console.log("About to save progress")
+    console.log("About to save progress");
     await guidedSaveProgress();
   } catch (error) {
     const eMessage = userErrorMessage(error);
@@ -13953,7 +13953,7 @@ const guidedCreateOrRenameDataset = async (bfAccount, datasetName) => {
 };
 
 const guidedAddDatasetSubtitle = async (bfAccount, datasetName, datasetSubtitle) => {
-  let isGuest = await window.isWorkspaceGuest()
+  let isGuest = await window.isWorkspaceGuest();
   if (isGuest) return;
   document.getElementById("guided-dataset-subtitle-upload-tr").classList.remove("hidden");
   const datasetSubtitleUploadText = document.getElementById("guided-dataset-subtitle-upload-text");
@@ -14037,7 +14037,7 @@ const guidedAddDatasetDescription = async (
   dataCollection,
   dataConclusion
 ) => {
-  let isGuest = await window.isWorkspaceGuest()
+  let isGuest = await window.isWorkspaceGuest();
   if (isGuest) return;
   document.getElementById("guided-dataset-description-upload-tr").classList.remove("hidden");
   const datasetDescriptionUploadText = document.getElementById(
@@ -14118,7 +14118,7 @@ const guidedAddDatasetDescription = async (
 };
 
 const uploadValidBannerImage = async (bfAccount, datasetName, bannerImagePath) => {
-  let isGuest = await window.isWorkspaceGuest()
+  let isGuest = await window.isWorkspaceGuest();
   if (isGuest) return;
   document.getElementById("guided-dataset-banner-image-upload-tr").classList.remove("hidden");
   const datasetBannerImageUploadText = document.getElementById(
@@ -14226,7 +14226,7 @@ const guidedAddDatasetBannerImage = async (bfAccount, datasetName, bannerImagePa
   await uploadValidBannerImage(bfAccount, datasetName, bannerImagePath);
 };
 const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) => {
-  let isGuest = await window.isWorkspaceGuest()
+  let isGuest = await window.isWorkspaceGuest();
   if (isGuest) return;
   document.getElementById("guided-dataset-license-upload-tr").classList.remove("hidden");
   const datasetLicenseUploadText = document.getElementById("guided-dataset-license-upload-text");
@@ -14303,7 +14303,7 @@ const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) =
 };
 
 const guidedAddDatasetTags = async (bfAccount, datasetName, tags) => {
-  let isGuest = await window.isWorkspaceGuest()
+  let isGuest = await window.isWorkspaceGuest();
   if (isGuest) return;
   document.getElementById("guided-dataset-tags-upload-tr").classList.remove("hidden");
   const datasetTagsUploadText = document.getElementById("guided-dataset-tags-upload-text");

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -428,11 +428,11 @@ const checkIfChangesMetadataPageShouldBeShown = async (pennsieveDatasetID) => {
   // let isGuest = await window.isWorkspaceGuest();
   let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
   let ineligible = false;
-  if(existingDataset) {
+  if (existingDataset) {
     let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
-    if(role === "editor") {
+    if (role === "editor") {
       ineligible = true;
-    } 
+    }
   }
 
   if (ineligible) return { shouldShow: false };
@@ -13967,14 +13967,14 @@ const guidedAddDatasetSubtitle = async (bfAccount, datasetName, datasetSubtitle)
   let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
 
   let ineligible = false;
-  if(existingDataset) {
+  if (existingDataset) {
     let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
-    if(role === "editor") {
+    if (role === "editor") {
       ineligible = true;
-    } 
+    }
   }
 
-  if (ineligible) return 
+  if (ineligible) return;
 
   document.getElementById("guided-dataset-subtitle-upload-tr").classList.remove("hidden");
   const datasetSubtitleUploadText = document.getElementById("guided-dataset-subtitle-upload-text");
@@ -14061,14 +14061,14 @@ const guidedAddDatasetDescription = async (
   let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
 
   let ineligible = false;
-  if(existingDataset) {
+  if (existingDataset) {
     let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
-    if(role === "editor") {
+    if (role === "editor") {
       ineligible = true;
-    } 
+    }
   }
 
-  if (ineligible) return 
+  if (ineligible) return;
   document.getElementById("guided-dataset-description-upload-tr").classList.remove("hidden");
   const datasetDescriptionUploadText = document.getElementById(
     "guided-dataset-description-upload-text"
@@ -14151,14 +14151,14 @@ const uploadValidBannerImage = async (bfAccount, datasetName, bannerImagePath) =
   let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
 
   let ineligible = false;
-  if(existingDataset) {
+  if (existingDataset) {
     let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
-    if(role === "editor") {
+    if (role === "editor") {
       ineligible = true;
-    } 
+    }
   }
 
-  if (ineligible) return 
+  if (ineligible) return;
   document.getElementById("guided-dataset-banner-image-upload-tr").classList.remove("hidden");
   const datasetBannerImageUploadText = document.getElementById(
     "guided-dataset-banner-image-upload-text"
@@ -14267,14 +14267,14 @@ const guidedAddDatasetBannerImage = async (bfAccount, datasetName, bannerImagePa
 const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) => {
   let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
   let ineligible = false;
-  if(existingDataset) {
+  if (existingDataset) {
     let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
-    if(role === "editor") {
+    if (role === "editor") {
       ineligible = true;
-    } 
+    }
   }
 
-  if (ineligible) return 
+  if (ineligible) return;
   document.getElementById("guided-dataset-license-upload-tr").classList.remove("hidden");
   const datasetLicenseUploadText = document.getElementById("guided-dataset-license-upload-text");
   datasetLicenseUploadText.innerHTML = "Adding dataset license...";
@@ -14352,14 +14352,14 @@ const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) =
 const guidedAddDatasetTags = async (bfAccount, datasetName, tags) => {
   let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
   let ineligible = false;
-  if(existingDataset) {
+  if (existingDataset) {
     let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
-    if(role === "editor") {
+    if (role === "editor") {
       ineligible = true;
-    } 
+    }
   }
 
-  if (ineligible) return 
+  if (ineligible) return;
   document.getElementById("guided-dataset-tags-upload-tr").classList.remove("hidden");
   const datasetTagsUploadText = document.getElementById("guided-dataset-tags-upload-text");
   datasetTagsUploadText.innerHTML = "Adding dataset tags...";

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -425,8 +425,17 @@ document.getElementById("guided-button-has-docs-data").addEventListener("click",
 const checkIfChangesMetadataPageShouldBeShown = async (pennsieveDatasetID) => {
   // TODO: Brioader support for guests who are editing a changed dataset.
 
-  let isGuest = await window.isWorkspaceGuest();
-  if (isGuest) return { shouldShow: false };
+  // let isGuest = await window.isWorkspaceGuest();
+  let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
+  let ineligible = false;
+  if(existingDataset) {
+    let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
+    if(role === "editor") {
+      ineligible = true;
+    } 
+  }
+
+  if (ineligible) return { shouldShow: false };
   try {
     const changesRes = await client.get(`/prepare_metadata/readme_changes_file`, {
       params: {
@@ -697,6 +706,8 @@ const savePageChanges = async (pageBeingLeftID) => {
           window.defaultBfAccount,
           selectedPennsieveDataset
         );
+
+        console.log("datasetIsLocked", datasetIsLocked);
         if (datasetIsLocked) {
           errorArray.push({
             type: "swal",
@@ -13953,8 +13964,18 @@ const guidedCreateOrRenameDataset = async (bfAccount, datasetName) => {
 };
 
 const guidedAddDatasetSubtitle = async (bfAccount, datasetName, datasetSubtitle) => {
-  let isGuest = await window.isWorkspaceGuest();
-  if (isGuest) return;
+  let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
+
+  let ineligible = false;
+  if(existingDataset) {
+    let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
+    if(role === "editor") {
+      ineligible = true;
+    } 
+  }
+
+  if (ineligible) return 
+
   document.getElementById("guided-dataset-subtitle-upload-tr").classList.remove("hidden");
   const datasetSubtitleUploadText = document.getElementById("guided-dataset-subtitle-upload-text");
   datasetSubtitleUploadText.innerHTML = "Adding dataset subtitle...";
@@ -14037,8 +14058,17 @@ const guidedAddDatasetDescription = async (
   dataCollection,
   dataConclusion
 ) => {
-  let isGuest = await window.isWorkspaceGuest();
-  if (isGuest) return;
+  let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
+
+  let ineligible = false;
+  if(existingDataset) {
+    let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
+    if(role === "editor") {
+      ineligible = true;
+    } 
+  }
+
+  if (ineligible) return 
   document.getElementById("guided-dataset-description-upload-tr").classList.remove("hidden");
   const datasetDescriptionUploadText = document.getElementById(
     "guided-dataset-description-upload-text"
@@ -14118,8 +14148,17 @@ const guidedAddDatasetDescription = async (
 };
 
 const uploadValidBannerImage = async (bfAccount, datasetName, bannerImagePath) => {
-  let isGuest = await window.isWorkspaceGuest();
-  if (isGuest) return;
+  let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
+
+  let ineligible = false;
+  if(existingDataset) {
+    let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
+    if(role === "editor") {
+      ineligible = true;
+    } 
+  }
+
+  if (ineligible) return 
   document.getElementById("guided-dataset-banner-image-upload-tr").classList.remove("hidden");
   const datasetBannerImageUploadText = document.getElementById(
     "guided-dataset-banner-image-upload-text"
@@ -14226,8 +14265,16 @@ const guidedAddDatasetBannerImage = async (bfAccount, datasetName, bannerImagePa
   await uploadValidBannerImage(bfAccount, datasetName, bannerImagePath);
 };
 const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) => {
-  let isGuest = await window.isWorkspaceGuest();
-  if (isGuest) return;
+  let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
+  let ineligible = false;
+  if(existingDataset) {
+    let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
+    if(role === "editor") {
+      ineligible = true;
+    } 
+  }
+
+  if (ineligible) return 
   document.getElementById("guided-dataset-license-upload-tr").classList.remove("hidden");
   const datasetLicenseUploadText = document.getElementById("guided-dataset-license-upload-text");
   datasetLicenseUploadText.innerHTML = "Adding dataset license...";
@@ -14303,8 +14350,16 @@ const guidedAddDatasetLicense = async (bfAccount, datasetName, datasetLicense) =
 };
 
 const guidedAddDatasetTags = async (bfAccount, datasetName, tags) => {
-  let isGuest = await window.isWorkspaceGuest();
-  if (isGuest) return;
+  let existingDataset = window.sodaJSONObj?.["starting-point"]?.["type"] === "bf";
+  let ineligible = false;
+  if(existingDataset) {
+    let role = await api.getDatasetRole(window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]);
+    if(role === "editor") {
+      ineligible = true;
+    } 
+  }
+
+  if (ineligible) return 
   document.getElementById("guided-dataset-tags-upload-tr").classList.remove("hidden");
   const datasetTagsUploadText = document.getElementById("guided-dataset-tags-upload-text");
   datasetTagsUploadText.innerHTML = "Adding dataset tags...";

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -8048,13 +8048,6 @@ window.guidedResumeProgress = async (datasetNameToResume) => {
       guidedSkipPage(pageID);
     }
 
-    let guest = await window.isWorkspaceGuest();
-    if (!guest) {
-      guidedUnSkipPage("guided-designate-permissions-tab");
-    } else {
-      guidedSkipPage("guided-designate-permissions-tab");
-    }
-
     // check if the user is an editor
     let userDatasetRole = await api.getDatasetRole(
       window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]
@@ -8066,10 +8059,15 @@ window.guidedResumeProgress = async (datasetNameToResume) => {
       guidedSkipPage("guided-assign-license-tab");
     } else {
       guidedUnSkipPage("guided-banner-image-tab");
-      if (!guest) {
-        guidedUnSkipPage("guided-designate-permissions-tab");
-      }
+      guidedUnSkipPage("guided-designate-permissions-tab");
       guidedUnSkipPage("guided-assign-license-tab");
+    }
+
+    let guest = await window.isWorkspaceGuest();
+    if (!guest) {
+      guidedUnSkipPage("guided-designate-permissions-tab");
+    } else {
+      guidedSkipPage("guided-designate-permissions-tab");
     }
 
     // Skip this page incase it was not skipped in a previous session

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -423,6 +423,10 @@ document.getElementById("guided-button-has-docs-data").addEventListener("click",
 });
 
 const checkIfChangesMetadataPageShouldBeShown = async (pennsieveDatasetID) => {
+  // TODO: Brioader support for guests who are editing a changed dataset.
+
+  let isGuest = await window.isWorkspaceGuest();
+  if (isGuest) return { shouldShow: false };
   try {
     const changesRes = await client.get(`/prepare_metadata/readme_changes_file`, {
       params: {
@@ -6285,6 +6289,8 @@ window.openPage = async (targetPageID) => {
     }
 
     if (targetPageID === "guided-designate-permissions-tab") {
+      let isGuest = await window.isWorkspaceGuest();
+      if (isGuest) return;
       // Get the users that can be granted permissions
       const usersReq = await client.get(
         `manage_datasets/ps_get_users?selected_account=${window.defaultBfAccount}`

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -981,6 +981,12 @@ const savePageChanges = async (pageBeingLeftID) => {
         window.sodaJSONObj["digital-metadata"]["dataset-workspace"] =
           guidedGetCurrentUserWorkSpace();
         guidedSkipPage("guided-pennsieve-intro-tab");
+
+        // check if user is a guest in the worksapce
+        let guest = await window.isWorkspaceGuest();
+        if (guest) {
+          guidedSkipPage("guided-designate-permissions-tab");
+        }
       }
 
       //Skip this page becausae we should not come back to it

--- a/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
+++ b/src/renderer/src/scripts/guided-mode/guided-curate-dataset.js
@@ -7983,6 +7983,21 @@ window.guidedResumeProgress = async (datasetNameToResume) => {
           `);
         }
 
+        // check if the user is an editor
+        let userDatasetRole = await api.getDatasetRole(
+          window.sodaJSONObj["digital-metadata"]["name"]
+        );
+
+        if (userDatasetRole === "editor") {
+          guidedSkipPage("guided-banner-image-tab");
+          guidedSkipPage("guided-designate-permissions-tab");
+          guidedSkipPage("guided-assign-license-tab");
+        } else {
+          guidedUnSkipPage("guided-banner-image-tab");
+          guidedUnSkipPage("guided-designate-permissions-tab");
+          guidedUnSkipPage("guided-assign-license-tab");
+        }
+
         if (Object.keys(datasetResumeJsonObj["previously-uploaded-data"]).length > 0) {
           await Swal.fire({
             icon: "info",
@@ -8048,26 +8063,13 @@ window.guidedResumeProgress = async (datasetNameToResume) => {
       guidedSkipPage(pageID);
     }
 
-    // check if the user is an editor
-    let userDatasetRole = await api.getDatasetRole(
-      window.sodaJSONObj["bf-dataset-selected"]["dataset-name"]
-    );
-
-    if (userDatasetRole === "editor") {
-      guidedSkipPage("guided-banner-image-tab");
-      guidedSkipPage("guided-designate-permissions-tab");
-      guidedSkipPage("guided-assign-license-tab");
-    } else {
-      guidedUnSkipPage("guided-banner-image-tab");
-      guidedUnSkipPage("guided-designate-permissions-tab");
-      guidedUnSkipPage("guided-assign-license-tab");
-    }
-
-    let guest = await window.isWorkspaceGuest();
-    if (!guest) {
-      guidedUnSkipPage("guided-designate-permissions-tab");
-    } else {
-      guidedSkipPage("guided-designate-permissions-tab");
+    if (hasConnectedAccountWithPennsieve()) {
+      let guest = await window.isWorkspaceGuest();
+      if (!guest) {
+        guidedUnSkipPage("guided-designate-permissions-tab");
+      } else {
+        guidedSkipPage("guided-designate-permissions-tab");
+      }
     }
 
     // Skip this page incase it was not skipped in a previous session

--- a/src/renderer/src/scripts/meta/announcements.json
+++ b/src/renderer/src/scripts/meta/announcements.json
@@ -1,10 +1,11 @@
 {
   "15.3.0": {
     "announcements": {
-      "bug-fixes": [
-      ],
-      "features": ["SODA will notify users if it is determined that a network setting may be preventing communication to the Pennsieve platform.",
-    "The `Prepare Dataset Step-by-Step` feature allows users to resume curating a dataset even when that dataset saved files that have since been deleted from the computer."]
+      "bug-fixes": [],
+      "features": [
+        "SODA will notify users if it is determined that a network setting may be preventing communication to the Pennsieve platform.",
+        "The `Prepare Dataset Step-by-Step` feature allows users to resume curating a dataset even when that dataset saved files that have since been deleted from the computer."
+      ]
     }
   },
   "15.2.2": {

--- a/src/renderer/src/scripts/meta/announcements.json
+++ b/src/renderer/src/scripts/meta/announcements.json
@@ -1,4 +1,12 @@
 {
+  "15.3.0": {
+    "announcements": {
+      "bug-fixes": [
+      ],
+      "features": ["SODA will notify users if it is determined that a network setting may be preventing communication to the Pennsieve platform.",
+    "The `Prepare Dataset Step-by-Step` feature allows users to resume curating a dataset even when that dataset saved files that have since been deleted from the computer."]
+    }
+  },
   "15.2.2": {
     "announcements": {
       "bug-fixes": [

--- a/src/renderer/src/scripts/others/api/api.js
+++ b/src/renderer/src/scripts/others/api/api.js
@@ -53,7 +53,7 @@ const isDatasetLocked = async (account, datasetNameOrId) => {
       );
       teamsInCurrentUsersOrganization = teamsReq.data.teams;
     } catch (error) {
-      userErrorMessage(error);
+      clientError(error);
     }
 
     // Get the team with the name "Publishers" (if it exists)

--- a/src/renderer/src/scripts/others/api/api.js
+++ b/src/renderer/src/scripts/others/api/api.js
@@ -539,7 +539,6 @@ const getLocalRemoteComparisonResults = async (datasetId, localDatasetPath) => {
   const response = await client.get(
     `/datasets/${datasetId}/comparison_results?local_dataset_path=${localDatasetPath}`
   );
-  console.log(response.data);
   return response.data;
 };
 

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -545,7 +545,6 @@ const initializeSODARenderer = async () => {
 initializeSODARenderer();
 
 const abortPennsieveAgentCheck = (pennsieveAgentStatusDivId) => {
-  console.log("CHange for build");
   setPennsieveAgentCheckSuccessful(false);
   if (!pennsieveAgentStatusDivId) {
     return;


### PR DESCRIPTION
## Summary by Sourcery

Add support for guest contributors in SDOA's end-to-end curation mode, allowing them to bypass certain permission steps. Enhance role checking logic to prevent ineligible actions for users with specific roles. Improve logging for better dataset management insights and update CI workflows to accommodate new branch naming.

New Features:
- Introduce guest contributor support in SDOA's end-to-end curation mode, allowing users with guest roles to skip certain permission designation steps.

Enhancements:
- Improve dataset role checking to determine if a user is ineligible for certain actions based on their role, such as 'editor'.
- Enhance logging for user roles and dataset sorting to provide better insights during dataset management.

CI:
- Update CI workflows to trigger builds on the 'guest-contributor-fixes' branch instead of 'folder-build'.