### PR TITLE
chore: update docs links to latest docs refactor

### DIFF
--- a/src/pyflask/manageDatasets/manage_datasets.py
+++ b/src/pyflask/manageDatasets/manage_datasets.py
@@ -672,7 +672,7 @@ def bf_submit_dataset(accountname, bfdataset, pathdataset):
         submitdatastatus = "Done"
         invalid_dataset_messages = (
             invalid_dataset_messages
-            + "<br>Please remove invalid files/folders from your dataset before uploading. If you have hidden files present please remove them before upload. You can find more details <a target='_blank' rel='noopener noreferrer' href='https://docs.sodaforsparc.io/docs/common-errors/issues-regarding-hidden-files-or-folders'>here </a> on how to fix this issue."
+            + "<br>Please remove invalid files/folders from your dataset before uploading. If you have hidden files present please remove them before upload. You can find more details <a target='_blank' rel='noopener noreferrer' href='https://docs.sodaforsparc.io/docs/miscellaneous/common-errors/issues-regarding-hidden-files-or-folders'>here </a> on how to fix this issue."
         )
         did_fail = True
         did_upload = False
@@ -708,7 +708,7 @@ def bf_submit_dataset(accountname, bfdataset, pathdataset):
         except Exception as e:
             namespace_logger.error("Error uploading dataset files")
             namespace_logger.error(e)
-            raise Exception("The Pennsieve Agent has encountered an issue while uploading. Please retry the upload. If this issue persists please follow this <a target='_blank' rel='noopener noreferrer' href='https://docs.sodaforsparc.io/docs/how-to/how-to-reinstall-the-pennsieve-agent'> guide</a> on performing a full reinstallation of the Pennsieve Agent to fix the problem.")
+            raise Exception("The Pennsieve Agent has encountered an issue while uploading. Please retry the upload. If this issue persists please follow this <a target='_blank' rel='noopener noreferrer' href='https://docs.sodaforsparc.io/docs/miscellaneous/how-to/how-to-reinstall-the-pennsieve-agent'> guide</a> on performing a full reinstallation of the Pennsieve Agent to fix the problem.")
 
         submitdatastatus = "Done"
     except Exception as e:

--- a/src/pyflask/prepareMetadata/prepare_metadata.py
+++ b/src/pyflask/prepareMetadata/prepare_metadata.py
@@ -201,7 +201,7 @@ def upload_metadata_file(file_type, bfaccount, bfdataset, file_path, delete_afte
     except Exception as e:
         namespace_logger.error("Error uploading dataset files")
         namespace_logger.error(e)
-        raise Exception("The Pennsieve Agent has encountered an issue while uploading. Please retry the upload. If this issue persists please follow this <a target='_blank' rel='noopener noreferrer' href='https://docs.sodaforsparc.io/docs/how-to/how-to-reinstall-the-pennsieve-agent'> guide</a> on performing a full reinstallation of the Pennsieve Agent to fix the problem.")
+        raise Exception("The Pennsieve Agent has encountered an issue while uploading. Please retry the upload. If this issue persists please follow this <a target='_blank' rel='noopener noreferrer' href='https://docs.sodaforsparc.io/docs/miscellaneous/how-to/how-to-reinstall-the-pennsieve-agent'> guide</a> on performing a full reinstallation of the Pennsieve Agent to fix the problem.")
 
 
     # before we can remove files we need to wait for all of the Agent's threads/subprocesses to finish

--- a/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
+++ b/src/renderer/src/components/backgroundServices/PennsieveAgentCheckDisplay/index.jsx
@@ -74,7 +74,7 @@ const PennsieveAgentErrorMessageDisplay = ({ errorMessage }) => {
                   This is a known issue with the Pennsieve Agent. It can typically be resolved by
                   deleting the local Pennsieve Agent database files. You can refer to the
                   <ExternalLink
-                    href="https://docs.sodaforsparc.io/docs/common-errors/trouble-starting-the-pennsieve-agent-in-soda"
+                    href="https://docs.sodaforsparc.io/docs/miscellaneous/common-errors/trouble-starting-the-pennsieve-agent-in-soda"
                     buttonText="SODA documentation"
                     buttonType="anchor"
                   />
@@ -93,7 +93,7 @@ const PennsieveAgentErrorMessageDisplay = ({ errorMessage }) => {
                 <Text my="sm">
                   Please view the
                   <ExternalLink
-                    href="https://docs.sodaforsparc.io/docs/common-errors/trouble-starting-the-pennsieve-agent-in-soda"
+                    href="https://docs.sodaforsparc.io/docs/miscellaneous/common-errors/trouble-starting-the-pennsieve-agent-in-soda"
                     buttonText="SODA documentation"
                     buttonType="anchor"
                   />

--- a/src/renderer/src/scripts/check-firewall/checkFirewall.js
+++ b/src/renderer/src/scripts/check-firewall/checkFirewall.js
@@ -26,12 +26,13 @@ export const clientBlockedByExternalFirewall = async (url) => {
   }
 };
 
-let docsUrl = "https://docs.sodaforsparc.io/how-to/how-to-resolve-network-issues";
+let docsUrl =
+  "https://docs.sodaforsparc.io/docs/miscellaneous/how-to/how-to-resolve-network-issues";
 const copyClientIdToClipboard = () => {
   window.electron.ipcRenderer.invoke("clipboard-write", docsUrl, "clipboard");
 };
 
-const commonHTML = `<p style="text-align:left;">Please refer to the SODA documentation page on resolving this issue by either clicking <a href="https://docs.sodaforsparc.io/how-to/how-to-resolve-network-issues" target="_blank">here</a> or by copying the url to the documentation page with the copy icon below.</p>
+const commonHTML = `<p style="text-align:left;">Please refer to the SODA documentation page on resolving this issue by either clicking <a href="https://docs.sodaforsparc.io/docs/miscellaneous/how-to/how-to-resolve-network-issues" target="_blank">here</a> or by copying the url to the documentation page with the copy icon below.</p>
   
   <div style="display:flex; margin:auto;">
     <p style="margin-right: 10px;">${docsUrl}</p>

--- a/src/renderer/src/scripts/globals.js
+++ b/src/renderer/src/scripts/globals.js
@@ -1023,7 +1023,7 @@ window.addBfAccount = async (ev, verifyingOrganization = False) => {
       titleText = `<h3 style="text-align:center">Grant SODA access to your current workspace</h3><p class="tip-content" style="margin-top: .5rem">Your email and password will not be saved and not seen by anyone.</p>`;
     }
 
-    let footerText = `<a target='_blank' rel='noopener noreferrer' href="https://docs.sodaforsparc.io/docs/how-to/how-to-get-a-pennsieve-account" style="text-decoration: none;">I don't have a Pennsieve account</a>`;
+    let footerText = `<a target='_blank' rel='noopener noreferrer' href="https://docs.sodaforsparc.io/docs/miscellaneous/how-to/how-to-get-a-pennsieve-account" style="text-decoration: none;">I don't have a Pennsieve account</a>`;
     if (verifyingOrganization) {
       footerText = "";
     }
@@ -1138,7 +1138,7 @@ window.addBfAccount = async (ev, verifyingOrganization = False) => {
           if (response[0] == "failed") {
             let error_message = response[1];
             if (response[1]["message"] === "exceptions must derive from BaseException") {
-              error_message = `<div style="margin-top: .5rem; margin-right: 1rem; margin-left: 1rem;">It seems that you do not have access to your desired workspace on Pennsieve. See our <a target='_blank' rel='noopener noreferrer' href="https://docs.sodaforsparc.io/docs/next/how-to/how-to-get-a-pennsieve-account">[dedicated help page]</a> to learn how to get access</div>`;
+              error_message = `<div style="margin-top: .5rem; margin-right: 1rem; margin-left: 1rem;">It seems that you do not have access to your desired workspace on Pennsieve. See our <a target='_blank' rel='noopener noreferrer' href="https://docs.sodaforsparc.io/docs/miscellaneous/how-to/how-to-get-a-pennsieve-account">[dedicated help page]</a> to learn how to get access</div>`;
             }
             if (response[1]["message"] === "Error: Username or password was incorrect.") {
               error_message = `<div style="margin-top: .5rem; margin-right: 1rem; margin-left: 1rem;">Error: Username or password was incorrect</div>`;
@@ -2030,7 +2030,7 @@ window.openDropdownPrompt = async (ev, dropdown, show_timer = true) => {
         title: `<h3 style="text-align:center">To switch your organization please provide your email and password</h3><p class="tip-content" style="margin-top: .5rem">Your email and password will not be saved and not seen by anyone.</p>`,
         html: `<input type="text" id="ps_login" class="swal2-input" placeholder="Email Address for Pennsieve">
           <input type="password" id="ps_password" class="swal2-input" placeholder="Password">
-          <p class="tip-content"> If you are using ORCID to sign in to Pennsieve view the official SODA docs <a target="_blank" rel="noopener noreferrer" href="https://docs.sodaforsparc.io/docs/how-to/how-to-use-workspaces">here</a> to learn how to change your workspace in SODA. </p>`,
+          <p class="tip-content"> If you are using ORCID to sign in to Pennsieve view the official SODA docs <a target="_blank" rel="noopener noreferrer" href="https://docs.sodaforsparc.io/docs/miscellaneous/how-to/how-to-use-workspaces">here</a> to learn how to change your workspace in SODA. </p>`,
         showClass: {
           popup: "animate__animated animate__fadeInDown animate__faster",
         },

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -6036,7 +6036,7 @@ window.showBFAddAccountSweetalert = async (ev) => {
     backdrop: "rgba(0,0,0, 0.4)",
     heightAuto: false,
     allowOutsideClick: false,
-    footer: `<a target="_blank" href="https://docs.sodaforsparc.io/docs/connecting-to-pennsieve/connecting-with-api-key" style="text-decoration: none;">Help me get an API key</a>`,
+    footer: `<a target="_blank" href="https://docs.sodaforsparc.io/docs/soda-features/connecting-to-pennsieve/connecting-with-api-key" style="text-decoration: none;">Help me get an API key</a>`,
     didOpen: () => {
       let swal_container = document.getElementsByClassName("swal2-popup")[0];
       swal_container.style.width = "43rem";

--- a/src/renderer/src/sections/curate/curate.html
+++ b/src/renderer/src/sections/curate/curate.html
@@ -64,7 +64,7 @@
         <div class="need-help-div">
           <h2 style="font-size: 16px">Upload Dataset</h2>
           <a target="_blank"
-            href="https://docs.sodaforsparc.io/docs/Freeform%20Mode/prepare-dataset/organize-dataset" style="font-size: 16px;">Need help?</a>
+            href="https://docs.sodaforsparc.io/docs/soda-features/upload-dataset/organize-dataset" style="font-size: 16px;">Need help?</a>
         </div>
       </div>
     </header>
@@ -939,7 +939,7 @@
               ">
               Step 5: Review dataset information and start upload
               <a target="_blank" style="padding: 0px 0px 0px 5px" class="github-wiki-link"
-                href="https://docs.sodaforsparc.io/docs/Freeform%20Mode/prepare-dataset/step-7">
+                href="https://docs.sodaforsparc.io/docs/soda-features/upload-dataset/step-5">
               </a>
               <br /><br />
             </h3>
@@ -1135,7 +1135,7 @@
           ">
             Step 6: Verify Dataset Upload
             <a target="_blank" style="padding: 0px 0px 0px 5px" class="github-wiki-link"
-              href="https://docs.sodaforsparc.io/docs/Freeform%20Mode/prepare-dataset/step-7">
+              href="https://docs.sodaforsparc.io/docs/soda-features/upload-dataset/step-6">
             </a>
             <br /><br />
             </h3>


### PR DESCRIPTION
## Summary by Sourcery

Update all in-app and backend documentation URLs to match the new refactored Docs site structure.

Chores:
- Refresh Pennsieve account and workspace help links to use the new docs/miscellaneous/how-to paths
- Update dataset upload and preparation guide links to the new docs/soda-features/upload-dataset routes
- Redirect network troubleshooting, hidden file errors, and agent reinstall/troubleshooting links to the refactored documentation URLs