### PR TITLE
Remove skip folder option

### DIFF
--- a/src/renderer/src/scripts/advanced-features/compare-local-remote-dataset.js
+++ b/src/renderer/src/scripts/advanced-features/compare-local-remote-dataset.js
@@ -211,10 +211,6 @@ document.querySelector("#only-on-local-upload-selected").addEventListener("click
   document.querySelector("#confirm-account-workspace").click();
 
   document.querySelector("#dataset-upload-existing-dataset").click();
-  document.querySelector("#Question-generate-dataset-existing-folders-options").style.display =
-    "flex";
-  document.querySelector("#merge-folder-card").click();
-  document.querySelector("#replace-file-card").click();
 });
 
 document.querySelector("#only-on-pennsieve-delete-selected").addEventListener("click", async () => {

--- a/src/renderer/src/scripts/organize-dataset/curate-functions.js
+++ b/src/renderer/src/scripts/organize-dataset/curate-functions.js
@@ -809,8 +809,6 @@ document.getElementById("dataset-upload-new-dataset").addEventListener("click", 
       element.checked = false;
     });
     // Reset the merge option cards
-    document.getElementById("skip-folder-card").classList.remove("checked");
-    document.getElementById("skip-folder-card").classList.remove("non-selected");
     document.getElementById("merge-folder-card").classList.remove("checked");
     document.getElementById("merge-folder-card").classList.remove("non-selected");
     document.getElementById("replace-folder-card").classList.remove("checked");
@@ -927,8 +925,6 @@ document.getElementById("change-workspace-btn").addEventListener("click", async 
     element.checked = false;
   });
   // Remove checks from all the cards in step 3 (merge option cards)
-  document.getElementById("skip-folder-card").classList.remove("checked");
-  document.getElementById("skip-folder-card").classList.remove("non-selected");
   document.getElementById("merge-folder-card").classList.remove("checked");
   document.getElementById("merge-folder-card").classList.remove("non-selected");
   document.getElementById("replace-folder-card").classList.remove("checked");

--- a/src/renderer/src/scripts/organize-dataset/curate-functions.js
+++ b/src/renderer/src/scripts/organize-dataset/curate-functions.js
@@ -809,10 +809,6 @@ document.getElementById("dataset-upload-new-dataset").addEventListener("click", 
       element.checked = false;
     });
     // Reset the merge option cards
-    document.getElementById("merge-folder-card").classList.remove("checked");
-    document.getElementById("merge-folder-card").classList.remove("non-selected");
-    document.getElementById("replace-folder-card").classList.remove("checked");
-    document.getElementById("replace-folder-card").classList.remove("non-selected");
 
     document.getElementById("replace-file-card").classList.remove("non-selected");
     document.getElementById("replace-file-card").classList.remove("checked");
@@ -827,7 +823,6 @@ document.getElementById("dataset-upload-new-dataset").addEventListener("click", 
   document.getElementById("Question-new-dataset-upload-name").classList.add("checked");
 
   // hide the existing folder options
-  $("#Question-generate-dataset-existing-folders-options").addClass("hidden");
   $("#Question-generate-dataset-existing-files-options").addClass("hidden");
 
   // disable the continue btn
@@ -925,10 +920,6 @@ document.getElementById("change-workspace-btn").addEventListener("click", async 
     element.checked = false;
   });
   // Remove checks from all the cards in step 3 (merge option cards)
-  document.getElementById("merge-folder-card").classList.remove("checked");
-  document.getElementById("merge-folder-card").classList.remove("non-selected");
-  document.getElementById("replace-folder-card").classList.remove("checked");
-  document.getElementById("replace-folder-card").classList.remove("non-selected");
 
   document.getElementById("replace-file-card").classList.remove("non-selected");
   document.getElementById("replace-file-card").classList.remove("checked");
@@ -970,7 +961,6 @@ document.getElementById("change-workspace-btn").addEventListener("click", async 
   });
   document.getElementById("current-ps-dataset-generate").textContent = "None";
   // hide the existing folder/files options
-  $("#Question-generate-dataset-existing-folders-options").addClass("hidden");
   $("#Question-generate-dataset-existing-files-options").addClass("hidden");
   $("#please-wait-new-curate-div").show();
 

--- a/src/renderer/src/scripts/others/renderer.js
+++ b/src/renderer/src/scripts/others/renderer.js
@@ -5800,7 +5800,13 @@ const initiate_generate = async (resume = false) => {
       clearInterval(timerProgress);
       swalShowInfo(
         "No files were uploaded in this session",
-        "This happens when trying to update an existing dataset while using the skip options (selected on step 3) in a way that unintentionally ask SODA to skip files you want to upload to Pennsieve. Please try again by clicking the Curate and Share button in the sidebar."
+        `
+        <div style="text-align: left;">
+          This happens when updating an existing dataset with the 'merge' option for folders and the 'skip' option for files selected, and not adding new files to your local dataset.
+          You may try the upload again by clicking the Curate and Share button in the sidebar to get back to the upload process. If you believe this is an error, please contact us using the Contact Us page available in the side bar.
+          For more instructions on how to do that you may reference our documentation page <a href="https://docs.sodaforsparc.io/docs/miscellaneous/common-errors/sending-log-files-to-soda-team" target="_blank">here.</a>
+         </div>
+         `
       );
       return;
     }

--- a/src/renderer/src/scripts/others/tab-effects.js
+++ b/src/renderer/src/scripts/others/tab-effects.js
@@ -3196,8 +3196,6 @@ window.resetCurationTabs = () => {
     element.checked = false;
   });
   // Remove checks from all the cards in step 3 (merge option cards)
-  document.getElementById("skip-folder-card").classList.remove("checked");
-  document.getElementById("skip-folder-card").classList.remove("non-selected");
   document.getElementById("merge-folder-card").classList.remove("checked");
   document.getElementById("merge-folder-card").classList.remove("non-selected");
   document.getElementById("replace-folder-card").classList.remove("checked");

--- a/src/renderer/src/scripts/others/tab-effects.js
+++ b/src/renderer/src/scripts/others/tab-effects.js
@@ -234,50 +234,14 @@ const fill_info_details = () => {
     true
   );
 
-  // check if the user is generating on an existing dataset
-
-  if ($('input[name="generate-5"]:checked')[0]?.id === "existing-folders-duplicate") {
-    addCardDetail(
-      "For existing folders",
-      "Create a duplicate",
-      2,
-      "Question-generate-dataset-existing-folders-options",
-      true
-    );
-  } else if ($('input[name="generate-5"]:checked')[0]?.id === "existing-folders-replace") {
-    addCardDetail(
-      "For existing folders",
-      "Replace",
-      2,
-      "Question-generate-dataset-existing-folders-options",
-      true
-    );
-  } else if ($('input[name="generate-5"]:checked')[0]?.id === "existing-folders-merge") {
-    addCardDetail(
-      "For existing folders",
-      "Merge",
-      2,
-      "Question-generate-dataset-existing-folders-options",
-      true
-    );
-  } else if ($('input[name="generate-5"]:checked')[0]?.id === "existing-folders-skip") {
-    addCardDetail(
-      "For existing folders",
-      "Skip",
-      2,
-      "Question-generate-dataset-existing-folders-options",
-      true
-    );
-  } else {
-    // generating a new dataset show local dataset path
-    addCardDetail(
-      "Local dataset path",
-      document.getElementById("org-dataset-folder-path").innerHTML,
-      4,
-      "Question-getting-started-1",
-      true
-    );
-  }
+  // generating a new dataset show local dataset path
+  addCardDetail(
+    "Local dataset path",
+    document.getElementById("org-dataset-folder-path").innerHTML,
+    4,
+    "Question-getting-started-1",
+    true
+  );
 
   if (window.manifestFileCheck.checked) {
     addCardDetail("Manifest files", "Requested from SODA", 2, "pulse-manifest-checkbox", true);
@@ -292,10 +256,6 @@ const fill_info_details = () => {
 // element => element to scroll to in the page
 // pulse_animation => whether to pulse the element
 window.traverse_back = (amount, element = "", pulse_animation = false) => {
-  if (element === "Question-generate-dataset-existing-folders-options") {
-    $("#button-confirm-ps-dataset").click();
-    $("nextBtn").prop("disabled", true);
-  }
   for (i = 0; i < amount; i++) {
     window.nextPrev(-1);
   }
@@ -923,12 +883,6 @@ window.transitionSubQuestions = async (ev, currentDiv, parentDiv, button, catego
     $("#nextBtn").prop("disabled", true);
     $(ev).hide();
     return;
-  }
-
-  if (currentDiv === "Question-generate-dataset-existing-folders-options") {
-    // show the existing file options div
-    $("#Question-generate-dataset-existing-files-options").show();
-    $("#Question-generate-dataset-existing-files-options").removeClass("hidden");
   }
 
   if (currentDiv === "Question-generate-dataset-existing-files-options") {
@@ -1889,39 +1843,6 @@ window.transitionSubQuestionsButton = async (ev, currentDiv, parentDiv, button, 
     target.classList.add("show");
   }
 
-  // Step 6 - The Merge/Skip/Replace options for selecting how to upload data to an existing Pennsieve dataset
-  if (ev.getAttribute("data-next") === "Question-generate-dataset-existing-folders-options") {
-    if (!window.hasFiles) {
-      // select the Merge option for Folders
-      document.getElementById("existing-folders-merge").checked = true;
-      $("#existing-folders-merge").hide();
-      $("#Question-generate-dataset-existing-folders-options").hide();
-      // select the Skip option for Files
-      document.getElementById("existing-files-replace").checked = true;
-
-      // enable the continue button
-      $("#nextBtn").prop("disabled", false);
-
-      $("#para-continue-empty-ds-selected").text("Please continue below.");
-      $("#para-continue-empty-ds-selected").show();
-
-      // hide the confirm button
-      $("#button-confirm-ps-dataset").hide();
-
-      return;
-    }
-
-    // hide the confirm button
-    $("#button-confirm-ps-dataset").hide();
-
-    $("#Question-generate-dataset-existing-folders-options").show();
-    $("#Question-generate-dataset-existing-folders-options").removeClass("hidden");
-    document.getElementById("existing-folders-merge").checked = false;
-    document.getElementById("existing-files-replace").checked = false;
-
-    // continue as usual otherwise
-  }
-
   // if buttons: Add account and Confirm account were hidden, show them again here
   if (ev.getAttribute("data-next") === "Question-generate-dataset-ps-account") {
     $("#" + ev.getAttribute("data-next") + " button").show();
@@ -2823,48 +2744,6 @@ const hidePrevDivs = (currentDiv, category) => {
   // hide all other div siblings
   for (var i = 0; i < individualQuestions.length; i++) {
     if (currentDiv === individualQuestions[i].id) {
-      if (!(currentDiv === "Question-generate-dataset-existing-folders-options")) {
-        $(`#${currentDiv}`).nextAll().removeClass("show");
-        $(`#${currentDiv}`).nextAll().removeClass("prev");
-        $(`#${currentDiv}`).nextAll().removeClass("test2");
-
-        // /// remove all checkmarks and previous data input
-        $(`#${currentDiv}`).nextAll().find(".option-card.radio-button").removeClass("checked");
-        $(`#${currentDiv}`).nextAll().find(".option-card.radio-button").removeClass("non-selected");
-        $(`#${currentDiv}`).nextAll().find(".folder-input-check").prop("checked", false);
-        $(`#${currentDiv}`).nextAll().find("#curatebfdatasetlist").prop("selectedIndex", 0);
-
-        var childElements2 = $(`#${currentDiv}`).nextAll().find(".form-control");
-
-        for (var child of childElements2) {
-          if (child.id === "inputNewNameDataset" || child.id === "ps-rename-dataset-name") {
-            if (child.id === "ps-rename-dataset-name") {
-              if (
-                $(".ps-dataset-span")
-                  .html()
-                  .replace(/^\s+|\s+$/g, "") == "None" ||
-                $(".ps-dataset-span")
-                  .html()
-                  .replace(/^\s+|\s+$/g, "") == ""
-              ) {
-                $("#ps-rename-dataset-name").val(
-                  `${$(".ps-dataset-span")
-                    .html()
-                    .replace(/^\s+|\s+$/g, "")}`
-                );
-              }
-            } else {
-              $(`${child.id}`).val("");
-              $(`${child.id}`).attr("placeholder", "Type here");
-            }
-          } else {
-            if (document.getElementById(child.id)) {
-              $(`${child.id}`).val("");
-              $(`${child.id}`).attr("placeholder", "Browse here");
-            }
-          }
-        }
-      }
       break;
     }
   }
@@ -3039,6 +2918,7 @@ const updateJSONStructureBfDestination = () => {
     window.sodaJSONObj["generate-dataset"] = {
       destination: "ps",
       "generate-option": "existing-ps",
+      "if-existing": "merge",
     };
 
     if (window.sodaJSONObj["ps-dataset-selected"]) {
@@ -3051,25 +2931,9 @@ const updateJSONStructureBfDestination = () => {
       };
     }
 
-    // folder selection options
-    // answer to Question if generate on ps, then: how to handle existing files and folders
-    // The user selected to generate to an existing dataset on Pennsieve
-    // Set the generate option to existing-ps
-    if ($('input[name="generate-5"]:checked').length > 0) {
-      if ($('input[name="generate-5"]:checked')[0].id === "existing-folders-duplicate") {
-        window.sodaJSONObj["generate-dataset"]["if-existing"] = "create-duplicate";
-      } else if ($('input[name="generate-5"]:checked')[0].id === "existing-folders-replace") {
-        window.sodaJSONObj["generate-dataset"]["if-existing"] = "replace";
-      } else if ($('input[name="generate-5"]:checked')[0].id === "existing-folders-merge") {
-        window.sodaJSONObj["generate-dataset"]["if-existing"] = "merge";
-      } else if ($('input[name="generate-5"]:checked')[0].id === "existing-folders-skip") {
-        window.sodaJSONObj["generate-dataset"]["if-existing"] = "skip";
-      }
-    }
+    // file option selection
     if ($('input[name="generate-6"]:checked').length > 0) {
-      if ($('input[name="generate-6"]:checked')[0].id === "existing-files-duplicate") {
-        window.sodaJSONObj["generate-dataset"]["if-existing-files"] = "create-duplicate";
-      } else if ($('input[name="generate-6"]:checked')[0].id === "existing-files-replace") {
+      if ($('input[name="generate-6"]:checked')[0].id === "existing-files-replace") {
         window.sodaJSONObj["generate-dataset"]["if-existing-files"] = "replace";
       } else if ($('input[name="generate-6"]:checked')[0].id === "existing-files-skip") {
         window.sodaJSONObj["generate-dataset"]["if-existing-files"] = "skip";
@@ -3196,10 +3060,6 @@ window.resetCurationTabs = () => {
     element.checked = false;
   });
   // Remove checks from all the cards in step 3 (merge option cards)
-  document.getElementById("merge-folder-card").classList.remove("checked");
-  document.getElementById("merge-folder-card").classList.remove("non-selected");
-  document.getElementById("replace-folder-card").classList.remove("checked");
-  document.getElementById("replace-folder-card").classList.remove("non-selected");
 
   document.getElementById("replace-file-card").classList.remove("non-selected");
   document.getElementById("replace-file-card").classList.remove("checked");
@@ -3279,7 +3139,6 @@ window.wipeOutCurateProgress = () => {
   });
   document.getElementById("current-ps-dataset-generate").textContent = "None";
   // hide the existing folder/files options
-  $("#Question-generate-dataset-existing-folders-options").addClass("hidden");
   $("#Question-generate-dataset-existing-files-options").addClass("hidden");
   $("#please-wait-new-curate-div").show();
 

--- a/src/renderer/src/sections/curate/curate.html
+++ b/src/renderer/src/sections/curate/curate.html
@@ -503,7 +503,7 @@
                   justify-content: center;
                   margin: 10px auto;
                 ">
-                  <button id="button-confirm-ps-dataset" onclick="window.transitionSubQuestionsButton(this, 'Question-generate-dataset-ps-dataset', 'upload-destination-selection-tab', 'delete', 'individual-question generate-dataset')" data-next="Question-generate-dataset-existing-folders-options" style="
+                  <button id="button-confirm-ps-dataset" onclick="window.transitionSubQuestionsButton(this, 'Question-generate-dataset-ps-dataset', 'upload-destination-selection-tab', 'delete', 'individual-question generate-dataset')" data-next="Question-generate-dataset-existing-files-options" style="
                       display: none;
                       border-radius: 4px;
                       height: 30px;
@@ -545,77 +545,6 @@
                   ">
                   Confirm
                 </button>
-              </div>
-            </div>
-
-            <div class="individual-question generate-dataset" id="Question-generate-dataset-existing-folders-options">
-              <div class="ui form" style="width: 100%">
-                <div class="grouped fields">
-                  <label style="font-size: 17px; color: var(--color-bg-plum); text-align: center">How would you like to
-                    handle existing folders?
-                    <br /><span style="color: #898989; font-size: 12px">Please select one:</span>
-                  </label>
-                  <div class="info-dropdown mt-lg" style="margin:auto;">
-                    <p class="info-dropdown-text" data-dropdown-type="info">What do these options do?</p>
-                    <i class="fas fa-chevron-right"></i>
-                  </div>
-                  <div class="info-container">
-                    <p class="help-text mb-0">
-                      Tell SODA how to handle folders imported in step 1 that already
-                      exist (same name, same relative location) on your Pennsieve dataset:
-                    </p>
-                      <ul>
-                        <li>
-                          Merge: Upload new files into the existing folders. Also allows for adding new folders to the dataset. 
-                          Existing files will be handled as instructed in the next step.
-                        </li>
-                        <li>
-                          Replace: Delete existing folders on Pennsieve then upload new ones. Also allows for adding new folders to the dataset.
-                        </li>
-                      </ul>
-                  </div>
-                  <div style="display: flex; flex-direction: row; justify-content: center">
-                    <div style="margin: 15px 0">
-                      <!-- <button> -->
-                      <div id="merge-folder-card" class="option-card radio-button" data-next="Question-generate-dataset-existing-files-options"
-                        onclick="window.transitionSubQuestions(this, 'Question-generate-dataset-existing-folders-options', 'upload-destination-selection-tab', '', 'generate-dataset')">
-                        <div class="card-head">
-                          <div class="folder-checkbox">
-                            <input class="folder-input-check" name="generate-5" id="existing-folders-merge"
-                              type="radio" />
-                            <label for="existing-folders-merge"></label>
-                          </div>
-                        </div>
-                        <div class="card-body">
-                          <svg width="45px" height="45px" viewBox="0 0 16 16" class="bi bi-intersect" fill="#13716D"
-                            xmlns="http://www.w3.org/2000/svg">
-                            <path fill-rule="evenodd"
-                              d="M0 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v2h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2H2a2 2 0 0 1-2-2V2zm5 10v2a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v5a2 2 0 0 1-2 2H5zm6-8H6a2 2 0 0 0-2 2v5H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1v2z" />
-                          </svg>
-                          <h2>Merge</h2>
-                        </div>
-                      </div>
-                    </div>
-                    <div style="margin: 15px 0">
-                      <!-- <button> -->
-                      <div id="replace-folder-card" class="option-card radio-button" data-next="Question-generate-dataset-existing-files-options"
-                        onclick="window.transitionSubQuestions(this, 'Question-generate-dataset-existing-folders-options', 'upload-destination-selection-tab', '', 'generate-dataset')">
-                        <div class="card-head">
-                          <div class="folder-checkbox">
-                            <input class="folder-input-check" name="generate-5" id="existing-folders-replace"
-                              type="radio" />
-                            <label for="existing-folders-replace"></label>
-                          </div>
-                        </div>
-                        <div class="card-body">
-                          <i class="fas fa-eraser" style="color: #b80d49; font-size: 43px"></i>
-                          <h2>Replace</h2>
-                        </div>
-                      </div>
-                    </div>
-
-                  </div>
-                </div>
               </div>
             </div>
 

--- a/src/renderer/src/sections/curate/curate.html
+++ b/src/renderer/src/sections/curate/curate.html
@@ -561,38 +561,20 @@
                   </div>
                   <div class="info-container">
                     <p class="help-text mb-0">
-                      Tell SODA how to handle folders specified during Step 3 that already
+                      Tell SODA how to handle folders imported in step 1 that already
                       exist (same name, same relative location) on your Pennsieve dataset:
                     </p>
                       <ul>
                         <li>
-                          Replace: Delete existing folders on Pennsieve then upload new ones
+                          Merge: Upload new files into the existing folders. Also allows for adding new folders to the dataset. 
+                          Existing files will be handled as instructed in the next step.
                         </li>
                         <li>
-                          Merge: Upload new files into the existing folders. Existing files will
-                          be handled as intructed in the next step.
+                          Replace: Delete existing folders on Pennsieve then upload new ones. Also allows for adding new folders to the dataset.
                         </li>
-                        <li>Skip: Existing folders will not be uploaded.</li>
                       </ul>
                   </div>
                   <div style="display: flex; flex-direction: row; justify-content: center">
-                    <div style="margin: 15px 0">
-                      <!-- <button> -->
-                      <div id="replace-folder-card" class="option-card radio-button" data-next="Question-generate-dataset-existing-files-options"
-                        onclick="window.transitionSubQuestions(this, 'Question-generate-dataset-existing-folders-options', 'upload-destination-selection-tab', '', 'generate-dataset')">
-                        <div class="card-head">
-                          <div class="folder-checkbox">
-                            <input class="folder-input-check" name="generate-5" id="existing-folders-replace"
-                              type="radio" />
-                            <label for="existing-folders-replace"></label>
-                          </div>
-                        </div>
-                        <div class="card-body">
-                          <i class="fas fa-eraser" style="color: #b80d49; font-size: 43px"></i>
-                          <h2>Replace</h2>
-                        </div>
-                      </div>
-                    </div>
                     <div style="margin: 15px 0">
                       <!-- <button> -->
                       <div id="merge-folder-card" class="option-card radio-button" data-next="Question-generate-dataset-existing-files-options"
@@ -616,26 +598,22 @@
                     </div>
                     <div style="margin: 15px 0">
                       <!-- <button> -->
-                      <div id="skip-folder-card" class="option-card radio-button" data-next="Question-generate-dataset-existing-files-options"
+                      <div id="replace-folder-card" class="option-card radio-button" data-next="Question-generate-dataset-existing-files-options"
                         onclick="window.transitionSubQuestions(this, 'Question-generate-dataset-existing-folders-options', 'upload-destination-selection-tab', '', 'generate-dataset')">
                         <div class="card-head">
                           <div class="folder-checkbox">
-                            <input class="folder-input-check" name="generate-5" id="existing-folders-skip"
+                            <input class="folder-input-check" name="generate-5" id="existing-folders-replace"
                               type="radio" />
-                            <label for="existing-folders-skip"></label>
+                            <label for="existing-folders-replace"></label>
                           </div>
                         </div>
                         <div class="card-body">
-                          <svg width="45px" height="45px" viewBox="0 0 16 16" class="bi bi-skip-forward" fill="#B80D49"
-                            xmlns="http://www.w3.org/2000/svg">
-                            <path fill-rule="evenodd"
-                              d="M15.5 3.5a.5.5 0 0 1 .5.5v8a.5.5 0 0 1-1 0V8.752l-6.267 3.636c-.52.302-1.233-.043-1.233-.696v-2.94l-6.267 3.636C.713 12.69 0 12.345 0 11.692V4.308c0-.653.713-.998 1.233-.696L7.5 7.248v-2.94c0-.653.713-.998 1.233-.696L15 7.248V4a.5.5 0 0 1 .5-.5zM1 4.633v6.734L6.804 8 1 4.633zm7.5 0v6.734L14.304 8 8.5 4.633z" />
-                          </svg>
-                          <!-- <i class="fas fa-forward" style="color: ;font-size:43px"></i> -->
-                          <h2>Skip</h2>
+                          <i class="fas fa-eraser" style="color: #b80d49; font-size: 43px"></i>
+                          <h2>Replace</h2>
                         </div>
                       </div>
                     </div>
+
                   </div>
                 </div>
               </div>
@@ -654,8 +632,8 @@
                     </div>
                     <div class="info-container">
                       <p class="help-text mb-0">
-                        Tell SODA how to handle files specified during Step 3 and metadata files
-                        specified during Step 4 that already exist (same name, same relative
+                        Tell SODA how to handle files imported in step 1
+                        that already exist (same name, same relative
                         location) on your Pennsieve dataset:
                       </p>
                         <ul>


### PR DESCRIPTION
## Summary by Sourcery

Remove the existing-folder selection step and default folder handling to merge when generating datasets, streamlining the dataset generation flow and updating related defaults and messaging.

Enhancements:
- Eliminate the "existing folders" option cards and all related UI sections and event handlers
- Set the folder handling option to "merge" by default in the generated JSON output
- Adjust navigation to skip directly to the file-handling step by updating the confirm button target
- Clean up transition and reset logic by removing references to the removed folder question
- Revise the upload error dialog to reflect the new merge-folder/skip-file context and include a documentation link
- Remove redundant folder-option code in the compare-local-remote-dataset script